### PR TITLE
Added Group Endpoints

### DIFF
--- a/api-reference/customers/get-customer.mdx
+++ b/api-reference/customers/get-customer.mdx
@@ -1,4 +1,4 @@
 ---
 title: "Get Customer"
-openapi: get /customers/{uniqid}
+openapi: get /customers/{id}
 ---

--- a/api-reference/customers/put-customers.mdx
+++ b/api-reference/customers/put-customers.mdx
@@ -1,4 +1,4 @@
 ---
 title: "Update Customer"
-openapi: put /customers/{uniqid}
+openapi: put /customers/{id}
 ---

--- a/api-reference/groups/delete-groups.mdx
+++ b/api-reference/groups/delete-groups.mdx
@@ -1,0 +1,4 @@
+---
+title: "Delete Group"
+openapi: delete /groups/{uniqid}
+---

--- a/api-reference/groups/get-group.mdx
+++ b/api-reference/groups/get-group.mdx
@@ -1,0 +1,4 @@
+---
+title: "Get Group"
+openapi: get /groups/{uniqid}
+---

--- a/api-reference/groups/list-groups.mdx
+++ b/api-reference/groups/list-groups.mdx
@@ -1,0 +1,4 @@
+---
+title: "List Groups"
+openapi: get /groups
+---

--- a/api-reference/groups/post-groups.mdx
+++ b/api-reference/groups/post-groups.mdx
@@ -1,0 +1,4 @@
+---
+title: "Create Group"
+openapi: post /groups
+---

--- a/api-reference/groups/put-groups.mdx
+++ b/api-reference/groups/put-groups.mdx
@@ -1,0 +1,4 @@
+---
+title: "Update Groups"
+openapi: put /groups/{uniqid}
+---

--- a/api-reference/information/get-self.mdx
+++ b/api-reference/information/get-self.mdx
@@ -1,0 +1,4 @@
+---
+title: "Get Current Shop"
+openapi: get /self
+---

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -548,7 +548,7 @@
             "$ref": "#/components/responses/categoryCreated"
           },
           "400": {
-            "$ref": "#/components/responses/categoryError"
+            "$ref": "#/components/responses/invalidTitleError"
           },
           "401": {
             "$ref": "#/components/responses/401"
@@ -671,7 +671,7 @@
             "$ref": "#/components/responses/categoryUpdated"
           },
           "400": {
-            "$ref": "#/components/responses/categoryError"
+            "$ref": "#/components/responses/invalidTitleError"
           },
           "401": {
             "$ref": "#/components/responses/401"
@@ -1003,6 +1003,205 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/feedbackReply"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          }
+        }
+      }
+    },
+    "/groups": {
+      "get": {
+        "tags": [
+          "Groups"
+        ],
+        "operationId": "getGroups",
+        "description": "List all the groups created on the current shop.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          },
+          {
+            "$ref": "#/components/parameters/page"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/groupListing"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Groups"
+        ],
+        "operationId": "createGroup",
+        "description": "Create a group",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          }
+        ],
+        "requestBody": {
+          "description": "group JSON to be created",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "title"
+                ],
+                "properties": {
+                  "title": {
+                    "type": "string",
+                    "example": "Software"
+                  },
+                  "unlisted": {
+                    "type": "boolean",
+                    "example": false
+                  },
+                  "sort_priority": {
+                    "type": "integer",
+                    "example": 0
+                  },
+                  "products_bound": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "example": [
+                      "sample8718521"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/groupCreated"
+          },
+          "400": {
+            "$ref": "#/components/responses/invalidTitleError"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          }
+        }
+      }
+    },
+    "/groups/{uniqid}": {
+      "get": {
+        "tags": [
+          "Groups"
+        ],
+        "operationId": "getGroup",
+        "description": "Get a specific group.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          },
+          {
+            "$ref": "#/components/parameters/uniqid"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/group"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Groups"
+        ],
+        "operationId": "deleteGroups",
+        "description": "Delete a groups.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          },
+          {
+            "$ref": "#/components/parameters/uniqid"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/groupDeleted"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Groups"
+        ],
+        "operationId": "updateGroup",
+        "description": "Update a group",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          },
+          {
+            "$ref": "#/components/parameters/uniqid"
+          }
+        ],
+        "requestBody": {
+          "description": "group JSON to be created",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "title"
+                ],
+                "properties": {
+                  "title": {
+                    "type": "string",
+                    "example": "Software"
+                  },
+                  "unlisted": {
+                    "type": "boolean",
+                    "example": false
+                  },
+                  "sort_priority": {
+                    "type": "integer",
+                    "example": 0
+                  },
+                  "products_bound": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "example": [
+                      "sample8718521"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/groupUpdated"
+          },
+          "400": {
+            "$ref": "#/components/responses/invalidTitleError"
           },
           "401": {
             "$ref": "#/components/responses/401"
@@ -3493,7 +3692,7 @@
           "updated_by": {
             "type": "integer",
             "example": 987,
-            "description": "User ID, available if the blacklist has been edited."
+            "description": "User ID of the user who updated the blaclist."
           }
         }
       },
@@ -3608,7 +3807,7 @@
           "updated_by": {
             "type": "integer",
             "example": 987,
-            "description": "User ID, available if the category has been edited."
+            "description": "User ID of the user who updated the category."
           },
           "products_bound": {
             "type": "array",
@@ -3625,7 +3824,7 @@
           "groups_bound": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/group"
+              "$ref": "#/components/schemas/miniGroup"
             },
             "description": "Array of groups."
           },
@@ -3677,7 +3876,7 @@
           },
           "image_attachment": {
             "type": "string",
-            "example": null,
+            "example": "null",
             "description": "DEPRECATED: Unique id of the image attachment for this product."
           },
           "description": {
@@ -3916,7 +4115,7 @@
           "updated_by": {
             "type": "integer",
             "example": 1,
-            "description": "User ID, available if the category has been edited."
+            "description": "User ID of the user who updated the coupon."
           },
           "products_bound": {
             "type": "array",
@@ -4076,7 +4275,7 @@
           "updated_by": {
             "type": "integer",
             "example": 1,
-            "description": "User ID, available if the category has been edited."
+            "description": "User ID of the user who updated the coupon."
           },
           "products_count": {
             "type": "integer",
@@ -5008,8 +5207,8 @@
           },
           "updated_by": {
             "type": "integer",
-            "example": 987,
-            "description": "User ID, available if the product has been edited."
+            "example": 1,
+            "description": "User ID of the user who updated the feedback."
           },
           "marketplace_category_id": {
             "type": "string",
@@ -5382,8 +5581,8 @@
           },
           "updated_by": {
             "type": "integer",
-            "example": 987,
-            "description": "User ID, available if the product has been edited."
+            "example": 1,
+            "description": "User ID of the user who updated the feedback."
           }
         }
       },
@@ -5712,12 +5911,14 @@
             "description": "Group title."
           },
           "image_attachment": {
-            "$ref": "#/components/schemas/image_attachment"
+            "type": "string",
+            "example": "50ab99797bd6b36f54089a7f6151c56e7a902be4bdaa4204e63961625bb9cb54",
+            "description": "DEPRECATED: Unique id of the image attachment for this product."
           },
           "unlisted": {
-            "type": "number",
-            "example": 1,
-            "description": "Whether or not the product is unlisted."
+            "type": "boolean",
+            "example": true,
+            "description": "Whether or not the group is unlisted."
           },
           "sort_priority": {
             "type": "number",
@@ -5736,15 +5937,106 @@
             "example": 162857125819,
             "description": "Date, available if the group has been edited."
           },
-          "category_id": {
-            "type": "string",
-            "example": "sample29a0e39d",
-            "description": "The category the group is a part of"
+          "updated_by": {
+            "type": "integer",
+            "example": 1,
+            "description": "User ID of the user who updated the group."
           },
-          "group_id": {
+          "products_bound": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/miniProduct"
+            }
+          },
+          "image_attachment_info": {
+            "$ref": "#/components/schemas/image_attachment"
+          },
+          "name": {
             "type": "string",
+            "example": "Sellix",
+            "description": "The name of the store the group is on."
+          }
+        }
+      },
+      "listedGroup": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "example": 987,
+            "description": "The ID of the resource"
+          },
+          "uniqid": {
+            "type": "string",
+            "format": "uuid",
             "example": "sample29a0e39d",
-            "description": "The unique identifyer of the current group"
+            "description": "Unique ID of the resource, used as reference across the API."
+          },
+          "shop_id": {
+            "type": "number",
+            "example": 987,
+            "description": "The unique identifyer for the shop."
+          },
+          "title": {
+            "type": "string",
+            "example": "Digital goods to download",
+            "description": "Group title."
+          },
+          "image_attachment": {
+            "type": "string",
+            "example": "50ab99797bd6b36f54089a7f6151c56e7a902be4bdaa4204e63961625bb9cb54",
+            "description": "DEPRECATED: Unique id of the image attachment for this product."
+          },
+          "unlisted": {
+            "type": "boolean",
+            "example": true,
+            "description": "Whether or not the group is unlisted."
+          },
+          "sort_priority": {
+            "type": "number",
+            "example": 1,
+            "description": "The priority of the group on the storefront."
+          },
+          "created_at": {
+            "type": "integer",
+            "format": "timestamp",
+            "example": 162857125819,
+            "description": "Timestamp for the creation of the group."
+          },
+          "updated_at": {
+            "type": "integer",
+            "format": "timestamp",
+            "example": 162857125819,
+            "description": "Date, available if the group has been edited."
+          },
+          "updated_by": {
+            "type": "integer",
+            "example": 1,
+            "description": "User ID of the user who updated the group."
+          },
+          "image_name": {
+            "type": "string",
+            "example": "SellixImageName.png",
+            "description": "DEPRECATED: The name of the product image with the file type"
+          },
+          "image_storage": {
+            "type": "string",
+            "example": "GROUPS",
+            "description": "Where the image is stored in Sellix's self-hosted CDN."
+          },
+          "cloudflare_image_id": {
+            "$ref": "#/components/schemas/cloudflare_image_id"
+          },
+          "products_bound": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/miniProduct"
+            }
+          },
+          "products_count": {
+            "type": "integer",
+            "example": 1,
+            "description": "The number of products in the group."
           }
         }
       },
@@ -6362,8 +6654,8 @@
           },
           "updated_by": {
             "type": "integer",
-            "example": 987,
-            "description": "User ID, available if the blacklist has been edited."
+            "example": 1,
+            "description": "User ID of the user who updated the invoice."
           },
           "approved_address": {
             "$ref": "#/components/schemas/approved_address"
@@ -7239,8 +7531,8 @@
           },
           "updated_by": {
             "type": "integer",
-            "example": 987,
-            "description": "User ID, available if the blacklist has been edited."
+            "example": 1,
+            "description": "User ID of the user who updated the invoice."
           },
           "is_evm_approved": {
             "type": "boolean",
@@ -7734,9 +8026,8 @@
           },
           "updated_by": {
             "type": "integer",
-            "format": "timestamp",
-            "example": 987,
-            "description": "User ID, available if the product has been edited."
+            "example": 1,
+            "description": "User ID of the user who updated the product."
           },
           "marketplace_category_id": {
             "type": "string",
@@ -7961,6 +8252,67 @@
                 }
               }
             }
+          }
+        }
+      },
+      "miniGroup": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "example": 987,
+            "description": "The ID of the resource"
+          },
+          "uniqid": {
+            "type": "string",
+            "format": "uuid",
+            "example": "sample29a0e39d",
+            "description": "Unique ID of the resource, used as reference across the API."
+          },
+          "shop_id": {
+            "type": "number",
+            "example": 987,
+            "description": "The unique identifyer for the shop."
+          },
+          "title": {
+            "type": "string",
+            "example": "Digital goods to download",
+            "description": "Group title."
+          },
+          "image_attachment": {
+            "$ref": "#/components/schemas/image_attachment"
+          },
+          "unlisted": {
+            "type": "number",
+            "example": 1,
+            "description": "Whether or not the group is unlisted."
+          },
+          "sort_priority": {
+            "type": "number",
+            "example": 1,
+            "description": "The priority of the group on the storefront."
+          },
+          "created_at": {
+            "type": "integer",
+            "format": "timestamp",
+            "example": 162857125819,
+            "description": "Timestamp for the creation of the group."
+          },
+          "updated_at": {
+            "type": "integer",
+            "format": "timestamp",
+            "example": 162857125819,
+            "description": "Date, available if the group has been edited."
+          },
+          "category_id": {
+            "type": "string",
+            "example": "sample29a0e39d",
+            "description": "The category the group is a part of"
+          },
+          "group_id": {
+            "type": "string",
+            "example": "sample29a0e39d",
+            "description": "The unique identifyer of the current group"
           }
         }
       },
@@ -8657,8 +9009,8 @@
           },
           "updated_by": {
             "type": "integer",
-            "example": 987,
-            "description": "User ID, available if the blacklist has been edited."
+            "example": 1,
+            "description": "User ID of the user who updated the invoice."
           },
           "is_marketplace": {
             "type": "integer",
@@ -8680,6 +9032,153 @@
             "type": "boolean",
             "example": true,
             "description": "If true, the merchant has enabled invoice shipment to the PayPal customer email."
+          }
+        }
+      },
+      "miniProduct": {
+        "type": "object",
+        "properties": {
+          "uniqid": {
+            "type": "string",
+            "format": "uuid",
+            "example": "sample29a0e39d",
+            "description": "Unique ID of the resource, used as reference across the API."
+          },
+          "price": {
+            "type": "string",
+            "example": "4.00",
+            "description": "Product price."
+          },
+          "price_display": {
+            "type": "string",
+            "example": "5.00",
+            "description": "Product price in currency."
+          },
+          "price_discount": {
+            "type": "number",
+            "example": 1,
+            "description": "The discount price on the purchased goods."
+          },
+          "currency": {
+            "$ref": "#/components/schemas/currency"
+          },
+          "unlisted": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Whether or not the product is shown on the storefront."
+          },
+          "title": {
+            "type": "string",
+            "example": "Digital good to download",
+            "description": "The title of the product"
+          },
+          "image_attachment": {
+            "type": "string",
+            "example": "8028e4db21744421e9645ed2abef4d303fd16a30fd4bb32f580d7a615ef6e0c7",
+            "description": "DEPRECATED: Unique id of the image attachment for this product."
+          },
+          "description": {
+            "type": "string",
+            "example": "Product description",
+            "description": "The description of the product"
+          },
+          "quantity_min": {
+            "type": "integer",
+            "minimum": 1,
+            "example": 1,
+            "description": "Minimum quantity purchasable of this product."
+          },
+          "quantity_max": {
+            "type": "integer",
+            "minimum": -1,
+            "example": -1,
+            "description": "Maximum quantity purchasable of this product."
+          },
+          "quantity_warning": {
+            "type": "integer",
+            "example": "0",
+            "description": "At which product quantity should we send a webhook and email warning the merchant."
+          },
+          "custom_fields": {
+            "$ref": "#/components/schemas/custom_fields_array"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "SERIALS",
+              "FILE",
+              "SERVICE",
+              "DYNAMIC",
+              "INFO_CARD",
+              "SUBSCRIPTION"
+            ],
+            "example": "SERVICE",
+            "description": "Product type."
+          },
+          "shop_id": {
+            "type": "number",
+            "example": 987,
+            "description": "The shop ID to which this resource belongs."
+          },
+          "gateways": {
+            "type": "string",
+            "example": "STRIPE,PAYPAL,CASH_APP,BITCOIN,LITECOIN,ETHEREUM,BITCOIN_CASH",
+            "description": "A list of gateways available on this product."
+          },
+          "crypto_confirmations_needed": {
+            "type": "integer",
+            "example": 3,
+            "description": "Minimum number of confirmations for a crypto payment to be accepted."
+          },
+          "private": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Whether or not the product is private and cannot be purchased."
+          },
+          "stock": {
+            "type": "integer",
+            "example": -1,
+            "description": "Stock of the current product, can be -1 for unlimited stock."
+          },
+          "sort_priority": {
+            "type": "integer",
+            "example": 1,
+            "description": "Sort order of this product."
+          },
+          "on_hold": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Whether or not the product is on hold and purchaseable."
+          },
+          "created_at": {
+            "type": "integer",
+            "format": "timestamp",
+            "example": 162857125819,
+            "description": "Timestamp for the creation of the product."
+          },
+          "updated_at": {
+            "type": "integer",
+            "format": "timestamp",
+            "example": 162857125819,
+            "description": "Date, available if the product has been edited."
+          },
+          "product_id": {
+            "type": "string",
+            "example": "sample29a0e39d",
+            "description": "The uniqid of the product"
+          },
+          "group_id": {
+            "type": "string",
+            "example": "sample29a0e39d",
+            "description": "If the product is in a group, this is the group_id of that group."
+          },
+          "average_score": {
+            "type": "string",
+            "example": "5.0000",
+            "description": "The average rating of the product."
           }
         }
       },
@@ -9267,8 +9766,8 @@
           },
           "updated_by": {
             "type": "integer",
-            "example": 987,
-            "description": "User ID, available if the product has been edited."
+            "example": 1,
+            "description": "User ID of the user who updated the product."
           },
           "marketplace_category_id": {
             "type": "string",
@@ -9919,8 +10418,8 @@
           },
           "updated_by": {
             "type": "integer",
-            "example": 987,
-            "description": "User ID, available if the query has been edited."
+            "example": 1,
+            "description": "User ID of the user who updated the query."
           },
           "messages": {
             "type": "array",
@@ -10005,8 +10504,8 @@
           },
           "updated_by": {
             "type": "integer",
-            "example": "0",
-            "description": "User ID, available if the query has been edited."
+            "example": 1,
+            "description": "User ID of the user who updated the query."
           }
         }
       },
@@ -11211,8 +11710,8 @@
           },
           "updated_by": {
             "type": "integer",
-            "example": 987,
-            "description": "User ID, available if the whitelist has been edited."
+            "example": 1,
+            "description": "User ID of the user who updated the whitelist."
           }
         }
       }
@@ -11586,221 +12085,6 @@
           }
         }
       },
-      "whitelistListing": {
-        "description": "resource retrieved",
-        "content": {
-          "application/json": {
-            "schema": {
-              "type": "object",
-              "properties": {
-                "status": {
-                  "type": "integer",
-                  "example": 200
-                },
-                "data": {
-                  "type": "object",
-                  "properties": {
-                    "whitelists": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/whitelist"
-                      }
-                    }
-                  }
-                },
-                "error": {
-                  "type": "string",
-                  "example": null
-                },
-                "message": {
-                  "type": "string",
-                  "example": null
-                },
-                "env": {
-                  "type": "string",
-                  "example": "production"
-                }
-              }
-            }
-          }
-        }
-      },
-      "whitelist": {
-        "description": "resource retrieved",
-        "content": {
-          "application/json": {
-            "schema": {
-              "type": "object",
-              "properties": {
-                "status": {
-                  "type": "integer",
-                  "example": 200
-                },
-                "data": {
-                  "type": "object",
-                  "properties": {
-                    "whitelist": {
-                      "$ref": "#/components/schemas/whitelist"
-                    }
-                  }
-                },
-                "error": {
-                  "type": "string",
-                  "example": null
-                },
-                "message": {
-                  "type": "string",
-                  "example": null
-                },
-                "env": {
-                  "type": "string",
-                  "example": "production"
-                }
-              }
-            }
-          }
-        }
-      },
-      "whitelistCreated": {
-        "description": "SUCCESS_MESSAGE",
-        "content": {
-          "application/json": {
-            "schema": {
-              "type": "object",
-              "properties": {
-                "status": {
-                  "type": "integer",
-                  "example": 200
-                },
-                "data": {
-                  "type": "object",
-                  "properties": {
-                    "uniqid": {
-                      "type": "string",
-                      "example": "sample29a0e39d"
-                    }
-                  }
-                },
-                "error": {
-                  "type": "string",
-                  "example": null
-                },
-                "message": {
-                  "type": "string",
-                  "example": "Whitelist Created Successfully."
-                },
-                "env": {
-                  "type": "string",
-                  "example": "production"
-                }
-              }
-            }
-          }
-        }
-      },
-      "whitelistUpdated": {
-        "description": "SUCCESS_MESSAGE",
-        "content": {
-          "application/json": {
-            "schema": {
-              "type": "object",
-              "properties": {
-                "status": {
-                  "type": "integer",
-                  "example": 200
-                },
-                "data": {
-                  "type": "object",
-                  "example": null
-                },
-                "error": {
-                  "type": "string",
-                  "example": null
-                },
-                "message": {
-                  "type": "string",
-                  "example": "Whitelist Edited Successfully."
-                },
-                "env": {
-                  "type": "string",
-                  "example": "production"
-                }
-              }
-            }
-          }
-        }
-      },
-      "whitelistDeleted": {
-        "description": "SUCCESS_MESSAGE",
-        "content": {
-          "application/json": {
-            "schema": {
-              "type": "object",
-              "properties": {
-                "status": {
-                  "type": "integer",
-                  "example": 200
-                },
-                "data": {
-                  "type": "object",
-                  "example": null
-                },
-                "error": {
-                  "type": "string",
-                  "example": null
-                },
-                "message": {
-                  "type": "string",
-                  "example": "Whitelist Deleted Successfully."
-                },
-                "env": {
-                  "type": "string",
-                  "example": "production"
-                }
-              }
-            }
-          }
-        }
-      },
-      "categoryListing": {
-        "description": "resource retrieved",
-        "content": {
-          "application/json": {
-            "schema": {
-              "type": "object",
-              "properties": {
-                "status": {
-                  "type": "integer",
-                  "example": 200
-                },
-                "data": {
-                  "type": "object",
-                  "properties": {
-                    "categories": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/category"
-                      }
-                    }
-                  }
-                },
-                "error": {
-                  "type": "string",
-                  "example": null
-                },
-                "message": {
-                  "type": "string",
-                  "example": null
-                },
-                "env": {
-                  "type": "string",
-                  "example": "production"
-                }
-              }
-            }
-          }
-        }
-      },
       "category": {
         "description": "resource retrieved",
         "content": {
@@ -11874,7 +12158,7 @@
           }
         }
       },
-      "categoryError": {
+      "categoryDeleted": {
         "description": "resource retrieved",
         "content": {
           "application/json": {
@@ -11883,7 +12167,7 @@
               "properties": {
                 "status": {
                   "type": "integer",
-                  "example": 400
+                  "example": 200
                 },
                 "data": {
                   "type": "object",
@@ -11891,7 +12175,46 @@
                 },
                 "error": {
                   "type": "string",
-                  "example": "Insert a valid Title."
+                  "example": null
+                },
+                "message": {
+                  "type": "string",
+                  "example": "Category Deleted Successfully."
+                },
+                "env": {
+                  "type": "string",
+                  "example": "production"
+                }
+              }
+            }
+          }
+        }
+      },
+      "categoryListing": {
+        "description": "resource retrieved",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "integer",
+                  "example": 200
+                },
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "categories": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/category"
+                      }
+                    }
+                  }
+                },
+                "error": {
+                  "type": "string",
+                  "example": null
                 },
                 "message": {
                   "type": "string",
@@ -11943,7 +12266,7 @@
           }
         }
       },
-      "categoryDeleted": {
+      "coupon": {
         "description": "resource retrieved",
         "content": {
           "application/json": {
@@ -11957,9 +12280,8 @@
                 "data": {
                   "type": "object",
                   "properties": {
-                    "uniqid": {
-                      "type": "string",
-                      "example": "sample29a0e39d"
+                    "coupon": {
+                      "$ref": "#/components/schemas/coupon"
                     }
                   }
                 },
@@ -11969,7 +12291,39 @@
                 },
                 "message": {
                   "type": "string",
-                  "example": "Category Deleted Successfully."
+                  "example": null
+                },
+                "env": {
+                  "type": "string",
+                  "example": "production"
+                }
+              }
+            }
+          }
+        }
+      },
+      "couponDeleted": {
+        "description": "resource retrieved",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "integer",
+                  "example": 200
+                },
+                "data": {
+                  "type": "object",
+                  "example": null
+                },
+                "error": {
+                  "type": "string",
+                  "example": null
+                },
+                "message": {
+                  "type": "string",
+                  "example": "Coupon Deleted Successfully"
                 },
                 "env": {
                   "type": "string",
@@ -11999,42 +12353,6 @@
                       "items": {
                         "$ref": "#/components/schemas/couponListing"
                       }
-                    }
-                  }
-                },
-                "error": {
-                  "type": "string",
-                  "example": null
-                },
-                "message": {
-                  "type": "string",
-                  "example": null
-                },
-                "env": {
-                  "type": "string",
-                  "example": "production"
-                }
-              }
-            }
-          }
-        }
-      },
-      "coupon": {
-        "description": "resource retrieved",
-        "content": {
-          "application/json": {
-            "schema": {
-              "type": "object",
-              "properties": {
-                "status": {
-                  "type": "integer",
-                  "example": 200
-                },
-                "data": {
-                  "type": "object",
-                  "properties": {
-                    "coupon": {
-                      "$ref": "#/components/schemas/coupon"
                     }
                   }
                 },
@@ -12093,7 +12411,7 @@
           }
         }
       },
-      "couponDeleted": {
+      "customerListing": {
         "description": "resource retrieved",
         "content": {
           "application/json": {
@@ -12107,10 +12425,51 @@
                 "data": {
                   "type": "object",
                   "properties": {
-                    "uniqid": {
-                      "type": "string",
-                      "description": "The ID of the new coupon",
-                      "example": "sample29a0e39d"
+                    "products": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/customer"
+                      }
+                    }
+                  }
+                },
+                "message": {
+                  "type": "string",
+                  "example": null
+                },
+                "log": {
+                  "type": "object",
+                  "example": null
+                },
+                "error": {
+                  "type": "string",
+                  "example": null
+                },
+                "env": {
+                  "type": "string",
+                  "example": "production"
+                }
+              }
+            }
+          }
+        }
+      },
+      "customer": {
+        "description": "resource retrieved",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "integer",
+                  "example": 200
+                },
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "customer": {
+                      "$ref": "#/components/schemas/customer"
                     }
                   }
                 },
@@ -12120,7 +12479,120 @@
                 },
                 "message": {
                   "type": "string",
-                  "example": "Coupon Deleted Successfully"
+                  "example": null
+                },
+                "env": {
+                  "type": "string",
+                  "example": "production"
+                }
+              }
+            }
+          }
+        }
+      },
+      "customerCreated": {
+        "description": "resource retrieved",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "integer",
+                  "example": 200
+                },
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "customer_id": {
+                      "type": "string",
+                      "example": "cst_87b8as6ba9125",
+                      "description": "Customer ID"
+                    }
+                  }
+                },
+                "error": {
+                  "type": "string",
+                  "example": null
+                },
+                "message": {
+                  "type": "string",
+                  "example": null
+                },
+                "env": {
+                  "type": "string",
+                  "example": "production"
+                }
+              }
+            }
+          }
+        }
+      },
+      "customers": {
+        "description": "resource retrieved",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "integer",
+                  "example": 200
+                },
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "customers": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/customer"
+                      }
+                    }
+                  }
+                },
+                "message": {
+                  "type": "string",
+                  "example": null
+                },
+                "log": {
+                  "type": "object",
+                  "example": null
+                },
+                "error": {
+                  "type": "string",
+                  "example": null
+                },
+                "env": {
+                  "type": "string",
+                  "example": "production"
+                }
+              }
+            }
+          }
+        }
+      },
+      "customerUpdated": {
+        "description": "resource retrieved",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "integer",
+                  "example": 200
+                },
+                "data": {
+                  "type": "object",
+                  "example": null
+                },
+                "error": {
+                  "type": "string",
+                  "example": null
+                },
+                "message": {
+                  "type": "string",
+                  "example": "Customer updated"
                 },
                 "env": {
                   "type": "string",
@@ -12253,6 +12725,219 @@
                 "message": {
                   "type": "string",
                   "example": "Feedback Replied Successfully."
+                },
+                "env": {
+                  "type": "string",
+                  "example": "production"
+                }
+              }
+            }
+          }
+        }
+      },
+      "group": {
+        "description": "resource retrieved",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "integer",
+                  "example": 200
+                },
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "group": {
+                      "$ref": "#/components/schemas/group"
+                    }
+                  }
+                },
+                "error": {
+                  "type": "string",
+                  "example": null
+                },
+                "message": {
+                  "type": "string",
+                  "example": null
+                },
+                "env": {
+                  "type": "string",
+                  "example": "production"
+                }
+              }
+            }
+          }
+        }
+      },
+      "groupCreated": {
+        "description": "resource retrieved",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "integer",
+                  "example": 200
+                },
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "uniqid": {
+                      "type": "string",
+                      "example": "sample29a0e39d"
+                    }
+                  }
+                },
+                "error": {
+                  "type": "string",
+                  "example": null
+                },
+                "message": {
+                  "type": "string",
+                  "example": "Group Created Successfully."
+                },
+                "env": {
+                  "type": "string",
+                  "example": "production"
+                }
+              }
+            }
+          }
+        }
+      },
+      "groupDeleted": {
+        "description": "resource retrieved",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "integer",
+                  "example": 200
+                },
+                "data": {
+                  "type": "object",
+                  "example": null
+                },
+                "error": {
+                  "type": "string",
+                  "example": null
+                },
+                "message": {
+                  "type": "string",
+                  "example": "Group Deleted Successfully."
+                },
+                "env": {
+                  "type": "string",
+                  "example": "production"
+                }
+              }
+            }
+          }
+        }
+      },
+      "groupListing": {
+        "description": "resource retrieved",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "integer",
+                  "example": 200
+                },
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "group": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/listedGroup"
+                      }
+                    }
+                  }
+                },
+                "error": {
+                  "type": "string",
+                  "example": null
+                },
+                "message": {
+                  "type": "string",
+                  "example": null
+                },
+                "env": {
+                  "type": "string",
+                  "example": "production"
+                }
+              }
+            }
+          }
+        }
+      },
+      "groupUpdated": {
+        "description": "resource retrieved",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "integer",
+                  "example": 200
+                },
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "uniqid": {
+                      "type": "string",
+                      "example": "sample29a0e39d"
+                    }
+                  }
+                },
+                "error": {
+                  "type": "string",
+                  "example": null
+                },
+                "message": {
+                  "type": "string",
+                  "example": "Group Edited Successfully."
+                },
+                "env": {
+                  "type": "string",
+                  "example": "production"
+                }
+              }
+            }
+          }
+        }
+      },
+      "invalidTitleError": {
+        "description": "resource retrieved",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "integer",
+                  "example": 400
+                },
+                "data": {
+                  "type": "object",
+                  "example": null
+                },
+                "error": {
+                  "type": "string",
+                  "example": "Insert a valid Title."
+                },
+                "message": {
+                  "type": "string",
+                  "example": null
                 },
                 "env": {
                   "type": "string",
@@ -12456,6 +13141,127 @@
           }
         }
       },
+      "license": {
+        "description": "license object",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "integer",
+                  "example": 200
+                },
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "license": {
+                      "$ref": "#/components/schemas/license"
+                    }
+                  }
+                },
+                "error": {
+                  "type": "string",
+                  "example": null
+                },
+                "message": {
+                  "type": "string",
+                  "example": null
+                },
+                "env": {
+                  "type": "string",
+                  "example": "production"
+                }
+              }
+            }
+          }
+        }
+      },
+      "payment": {
+        "description": "payment creation response",
+        "content": {
+          "application/json": {
+            "schema": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/payment_response"
+                },
+                {
+                  "$ref": "#/components/schemas/payment_response_white_label"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "paymentCompleted": {
+        "description": "payment creation response",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "integer",
+                  "example": 200
+                },
+                "data": {
+                  "type": "object",
+                  "example": null
+                },
+                "error": {
+                  "type": "string",
+                  "example": null
+                },
+                "message": {
+                  "type": "string",
+                  "example": "Payment Completed Successfully."
+                },
+                "env": {
+                  "type": "string",
+                  "example": "production"
+                },
+                "log": {
+                  "type": "object",
+                  "example": null
+                }
+              }
+            }
+          }
+        }
+      },
+      "paymentVoided": {
+        "description": "payment creation response",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "integer",
+                  "example": 200
+                },
+                "data": {
+                  "type": "object",
+                  "example": null
+                },
+                "error": {
+                  "type": "string",
+                  "example": null
+                },
+                "message": {
+                  "type": "string",
+                  "example": "Payment Voided Successfully."
+                },
+                "env": {
+                  "type": "string",
+                  "example": "production"
+                }
+              }
+            }
+          }
+        }
+      },
       "productListing": {
         "description": "resource retrieved",
         "content": {
@@ -12649,10 +13455,6 @@
                 "env": {
                   "type": "string",
                   "example": "production"
-                },
-                "log": {
-                  "type": "object",
-                  "example": null
                 }
               }
             }
@@ -12862,25 +13664,8 @@
           }
         }
       },
-      "payment": {
-        "description": "payment creation response",
-        "content": {
-          "application/json": {
-            "schema": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/payment_response"
-                },
-                {
-                  "$ref": "#/components/schemas/payment_response_white_label"
-                }
-              ]
-            }
-          }
-        }
-      },
-      "paymentCompleted": {
-        "description": "payment creation response",
+      "shop": {
+        "description": "shop object",
         "content": {
           "application/json": {
             "schema": {
@@ -12891,242 +13676,13 @@
                   "example": 200
                 },
                 "data": {
-                  "type": "object",
-                  "example": null
+                  "$ref": "#/components/schemas/shop_info"
                 },
                 "error": {
                   "type": "string",
                   "example": null
                 },
                 "message": {
-                  "type": "string",
-                  "example": "Payment Completed Successfully."
-                },
-                "env": {
-                  "type": "string",
-                  "example": "production"
-                },
-                "log": {
-                  "type": "object",
-                  "example": null
-                }
-              }
-            }
-          }
-        }
-      },
-      "paymentVoided": {
-        "description": "payment creation response",
-        "content": {
-          "application/json": {
-            "schema": {
-              "type": "object",
-              "properties": {
-                "status": {
-                  "type": "integer",
-                  "example": 200
-                },
-                "data": {
-                  "type": "object",
-                  "example": null
-                },
-                "error": {
-                  "type": "string",
-                  "example": null
-                },
-                "message": {
-                  "type": "string",
-                  "example": "Payment Voided Successfully."
-                },
-                "env": {
-                  "type": "string",
-                  "example": "production"
-                }
-              }
-            }
-          }
-        }
-      },
-      "customerListing": {
-        "description": "resource retrieved",
-        "content": {
-          "application/json": {
-            "schema": {
-              "type": "object",
-              "properties": {
-                "status": {
-                  "type": "integer",
-                  "example": 200
-                },
-                "data": {
-                  "type": "object",
-                  "properties": {
-                    "products": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/customer"
-                      }
-                    }
-                  }
-                },
-                "message": {
-                  "type": "string",
-                  "example": null
-                },
-                "log": {
-                  "type": "object",
-                  "example": null
-                },
-                "error": {
-                  "type": "string",
-                  "example": null
-                },
-                "env": {
-                  "type": "string",
-                  "example": "production"
-                }
-              }
-            }
-          }
-        }
-      },
-      "customer": {
-        "description": "resource retrieved",
-        "content": {
-          "application/json": {
-            "schema": {
-              "type": "object",
-              "properties": {
-                "status": {
-                  "type": "integer",
-                  "example": 200
-                },
-                "data": {
-                  "type": "object",
-                  "properties": {
-                    "customer": {
-                      "$ref": "#/components/schemas/customer"
-                    }
-                  }
-                },
-                "error": {
-                  "type": "string",
-                  "example": null
-                },
-                "message": {
-                  "type": "string",
-                  "example": null
-                },
-                "env": {
-                  "type": "string",
-                  "example": "production"
-                }
-              }
-            }
-          }
-        }
-      },
-      "customerCreated": {
-        "description": "resource retrieved",
-        "content": {
-          "application/json": {
-            "schema": {
-              "type": "object",
-              "properties": {
-                "status": {
-                  "type": "integer",
-                  "example": 200
-                },
-                "data": {
-                  "type": "object",
-                  "properties": {
-                    "customer_id": {
-                      "type": "string",
-                      "example": "cst_87b8as6ba9125",
-                      "description": "Customer ID"
-                    }
-                  }
-                },
-                "error": {
-                  "type": "string",
-                  "example": null
-                },
-                "message": {
-                  "type": "string",
-                  "example": null
-                },
-                "env": {
-                  "type": "string",
-                  "example": "production"
-                }
-              }
-            }
-          }
-        }
-      },
-      "customerUpdated": {
-        "description": "resource retrieved",
-        "content": {
-          "application/json": {
-            "schema": {
-              "type": "object",
-              "properties": {
-                "status": {
-                  "type": "integer",
-                  "example": 200
-                },
-                "data": {
-                  "type": "object",
-                  "example": null
-                },
-                "error": {
-                  "type": "string",
-                  "example": null
-                },
-                "message": {
-                  "type": "string",
-                  "example": "Customer updated"
-                },
-                "env": {
-                  "type": "string",
-                  "example": "production"
-                }
-              }
-            }
-          }
-        }
-      },
-      "customers": {
-        "description": "resource retrieved",
-        "content": {
-          "application/json": {
-            "schema": {
-              "type": "object",
-              "properties": {
-                "status": {
-                  "type": "integer",
-                  "example": 200
-                },
-                "data": {
-                  "type": "object",
-                  "properties": {
-                    "customers": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/customer"
-                      }
-                    }
-                  }
-                },
-                "message": {
-                  "type": "string",
-                  "example": null
-                },
-                "log": {
-                  "type": "object",
-                  "example": null
-                },
-                "error": {
                   "type": "string",
                   "example": null
                 },
@@ -13239,8 +13795,8 @@
           }
         }
       },
-      "license": {
-        "description": "license object",
+      "whitelist": {
+        "description": "resource retrieved",
         "content": {
           "application/json": {
             "schema": {
@@ -13253,8 +13809,8 @@
                 "data": {
                   "type": "object",
                   "properties": {
-                    "license": {
-                      "$ref": "#/components/schemas/license"
+                    "whitelist": {
+                      "$ref": "#/components/schemas/whitelist"
                     }
                   }
                 },
@@ -13275,8 +13831,8 @@
           }
         }
       },
-      "shop": {
-        "description": "shop object",
+      "whitelistCreated": {
+        "description": "SUCCESS_MESSAGE",
         "content": {
           "application/json": {
             "schema": {
@@ -13287,7 +13843,84 @@
                   "example": 200
                 },
                 "data": {
-                  "$ref": "#/components/schemas/shop_info"
+                  "type": "object",
+                  "properties": {
+                    "uniqid": {
+                      "type": "string",
+                      "example": "sample29a0e39d"
+                    }
+                  }
+                },
+                "error": {
+                  "type": "string",
+                  "example": null
+                },
+                "message": {
+                  "type": "string",
+                  "example": "Whitelist Created Successfully."
+                },
+                "env": {
+                  "type": "string",
+                  "example": "production"
+                }
+              }
+            }
+          }
+        }
+      },
+      "whitelistDeleted": {
+        "description": "SUCCESS_MESSAGE",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "integer",
+                  "example": 200
+                },
+                "data": {
+                  "type": "object",
+                  "example": null
+                },
+                "error": {
+                  "type": "string",
+                  "example": null
+                },
+                "message": {
+                  "type": "string",
+                  "example": "Whitelist Deleted Successfully."
+                },
+                "env": {
+                  "type": "string",
+                  "example": "production"
+                }
+              }
+            }
+          }
+        }
+      },
+      "whitelistListing": {
+        "description": "resource retrieved",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "integer",
+                  "example": 200
+                },
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "whitelists": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/whitelist"
+                      }
+                    }
+                  }
                 },
                 "error": {
                   "type": "string",
@@ -13296,6 +13929,38 @@
                 "message": {
                   "type": "string",
                   "example": null
+                },
+                "env": {
+                  "type": "string",
+                  "example": "production"
+                }
+              }
+            }
+          }
+        }
+      },
+      "whitelistUpdated": {
+        "description": "SUCCESS_MESSAGE",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "integer",
+                  "example": 200
+                },
+                "data": {
+                  "type": "object",
+                  "example": null
+                },
+                "error": {
+                  "type": "string",
+                  "example": null
+                },
+                "message": {
+                  "type": "string",
+                  "example": "Whitelist Edited Successfully."
                 },
                 "env": {
                   "type": "string",

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -2612,7 +2612,7 @@
         ],
         "responses": {
           "200": {
-            "$ref": "#/components/responses/customers"
+            "$ref": "#/components/responses/customerListing"
           },
           "401": {
             "$ref": "#/components/responses/401"
@@ -2708,7 +2708,7 @@
             "$ref": "#/components/responses/customerCreated"
           },
           "400": {
-            "$ref": "#/components/responses/400"
+            "$ref": "#/components/responses/customerCreateError"
           },
           "401": {
             "$ref": "#/components/responses/401"
@@ -2827,7 +2827,7 @@
         },
         "responses": {
           "200": {
-            "$ref": "#/components/responses/200"
+            "$ref": "#/components/responses/customerUpdated"
           },
           "400": {
             "$ref": "#/components/responses/400"
@@ -4729,6 +4729,92 @@
             "items": {
               "$ref": "#/components/schemas/miniInvoice"
             }
+          }
+        }
+      },
+      "customerListing": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "cst_sample37atm91892",
+            "description": "Customer ID"
+          },
+          "shop_id": {
+            "type": "number",
+            "example": 987,
+            "description": "The shop ID to which this customer belongs."
+          },
+          "email": {
+            "type": "string",
+            "example": "sample@gmail.com",
+            "description": "Customer email"
+          },
+          "name": {
+            "type": "string",
+            "example": "James",
+            "description": "Customer name"
+          },
+          "surname": {
+            "type": "string",
+            "example": "Smith",
+            "description": "Customer surname"
+          },
+          "phone": {
+            "type": "string",
+            "example": 3287261000,
+            "description": "Customer phone"
+          },
+          "phone_country_code": {
+            "type": "string",
+            "example": "IT",
+            "description": "Customer phone country code"
+          },
+          "country_code": {
+            "type": "string",
+            "example": "IT",
+            "description": "Customer country code"
+          },
+          "street_address": {
+            "type": "string",
+            "example": "St. Rome 404",
+            "description": "Customer street address"
+          },
+          "additional_address_info": {
+            "type": "string",
+            "example": null,
+            "description": "Customer street address additional info"
+          },
+          "city": {
+            "type": "string",
+            "example": "Rome",
+            "description": "Customer city"
+          },
+          "postal_code": {
+            "type": "string",
+            "example": 987,
+            "description": "Customer postal code"
+          },
+          "state": {
+            "type": "string",
+            "example": "Italy",
+            "description": "Customer state"
+          },
+          "affiliate_revenue": {
+            "type": "string",
+            "example": "0.00",
+            "description": "Revenue customer has recieved from the affiliate program"
+          },
+          "affiliate_revenue_currency": {
+            "type": "string",
+            "example": "EUR",
+            "description": "The currency the customer gets reimbursed in for the affiliate program"
+          },
+          "created_at": {
+            "type": "integer",
+            "format": "timestamp",
+            "example": 162857125819,
+            "description": "Timestamp for the creation of the customer."
           }
         }
       },
@@ -12457,10 +12543,10 @@
                 "data": {
                   "type": "object",
                   "properties": {
-                    "products": {
+                    "customers": {
                       "type": "array",
                       "items": {
-                        "$ref": "#/components/schemas/customer"
+                        "$ref": "#/components/schemas/customerListing"
                       }
                     }
                   }
@@ -12546,6 +12632,38 @@
                 "error": {
                   "type": "string",
                   "example": null
+                },
+                "message": {
+                  "type": "string",
+                  "example": null
+                },
+                "env": {
+                  "type": "string",
+                  "example": "production"
+                }
+              }
+            }
+          }
+        }
+      },
+      "customerCreateError": {
+        "description": "resource retrieved",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "integer",
+                  "example": 400
+                },
+                "data": {
+                  "type": "object",
+                  "example": null
+                },
+                "error": {
+                  "type": "string",
+                  "example": "Email, Name and Surname are required."
                 },
                 "message": {
                   "type": "string",

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -65,6 +65,10 @@
     {
       "name": "Licenses",
       "description": "License endpoints"
+    },
+    {
+      "name": "Information",
+      "description": "Informative endpoints"
     }
   ],
   "paths": {
@@ -2942,6 +2946,28 @@
           }
         }
       }
+    },
+    "/self": {
+      "get": {
+        "tags": [
+          "Information"
+        ],
+        "operationId": "getSelf",
+        "description": "Get information about the current shop.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/shop"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          }
+        }
+      }
     }
   },
   "security": [
@@ -4768,7 +4794,7 @@
           },
           "youtube_link": {
             "type": "string",
-            "example": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            "example": "https://www.youtube.com/example",
             "description": "The url for the YouTube video of the product"
           },
           "volume_discounts": {
@@ -7466,7 +7492,7 @@
           },
           "youtube_link": {
             "type": "string",
-            "example": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            "example": "https://www.youtube.com/example",
             "description": "The url for the YouTube video of the product"
           },
           "volume_discounts": {
@@ -8996,7 +9022,7 @@
           },
           "youtube_link": {
             "type": "string",
-            "example": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            "example": "https://www.youtube.com/example",
             "description": "The url for the YouTube video of the product"
           },
           "volume_discounts": {
@@ -10226,6 +10252,530 @@
             "items": {
               "$ref": "#/components/schemas/invoiceListing"
             }
+          }
+        }
+      },
+      "shop_info": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "example": 987,
+            "description": "The ID of the shop"
+          },
+          "user_id": {
+            "type": "integer",
+            "example": 987,
+            "description": "The ID of the user who requested the shop info"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["DEFAULT"],
+            "example": "DEFAULT",
+            "description": "The type of the shop"
+          },
+          "name": {
+            "type": "string",
+            "example": "Sellix",
+            "description": "The name of the shop"
+          },
+          "avatar": {
+            "type": "string",
+            "example": "45ecddc105c6717eab77e499688b608437cd0de7fa2e8ced3af65f0648c94b4b",
+            "description": "The hash for the avatar"
+          },
+          "currency": {
+            "$ref": "#/components/schemas/currency"
+          },
+          "default_currency": {
+            "$ref": "#/components/schemas/currency"
+          },
+          "available_currency": {
+            "$ref": "#/components/schemas/currency"
+          },
+          "vat_percentage": {
+            "type": "string",
+            "example": "0.00",
+            "description": "The VAT percentage setup for the store"
+          },
+          "tax_configuration": {
+            "type": "string",
+            "example": "NONE",
+            "description": "The tax configuration for the shop"
+          },
+          "dashboard_feature": {
+            "type": "string",
+            "enum": ["API_CUSTOM", "EMBED", "PAYMENT_LINKS", "STORE", "POS", "PLUGINS", "UNSURE"],
+            "example": "STORE",
+            "description": "The organization mode set for the dashboard"
+          },
+          "display_tax_on_storefront": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "The tax percentage will be shown on the product cards of your storefront, and not on the checkout page and invoice PDF only."
+          },
+          "display_tax_custom_fields": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Whether the tax is displayed in custom fields"
+          }, 
+          "validation_only_for_companies": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Wheter or not VAT validation is only done for companies"
+          },
+          "validate_vat_number": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "If enabled, we will validate the Company VAT number to be sure it’s correct."
+          },
+          "prices_tax_inclusive": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Whether or not product pricing incldues the VAT"
+          },
+          "notify_trial_ending": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Send an email to your customers when the trial period is ending."
+          },
+          "notify_upcoming_renewal": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Send an email to your customers days before an upcoming renewal."
+          },
+          "notify_subscription_renewal_failure": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Send an email to your customers if a subscription renewal fails."
+          },
+          "order_emails": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Whether or not the shop owner receives emails for orders"
+          },
+          "subscription_grace_period": {
+            "type": "integer",
+            "example": 172800,
+            "description": "In days, how much time should we wait before cancelling a subscription if no payment is completed."
+          },
+          "paypal_credit_card": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Whether or not the shop accepts credit cards via PayPal"
+          },
+          "force_paypal_email_delivery": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Whether or not the shop delivers products to the PayPal email when the gateway is PAYPAL"
+          },
+          "paypal_merchant_id": {
+            "type": "string",
+            "example": null,
+            "description": "The PayPal merchant ID of the PayPal account linked to the shop"
+          },
+          "binance_id": {
+            "type": "string",
+            "example": null,
+            "description": "The Binance ID of the Binance account linked to the shop"
+          },
+          "walletconnect_id": {
+            "type": "string",
+            "example": null,
+            "description": "The WalletConnect ID of the WalletConnect account linked to the shop"
+          },
+          "non_custodial_wallet": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Whether or not the shop uses the Sellix non-custodial crypto wallet"
+          },
+          "dark_mode": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Whether or not the shop has dark mode enabled"
+          },
+          "discord_link": {
+            "type": "string",
+            "example": "https://discord.gg/example",
+            "description": "The Discord server invite link for the shop"
+          },
+          "twitter_link": {
+            "type": "string",
+            "example": "https://twitter.com/example",
+            "description": "The link to the shop's Twitter account"
+          },
+          "instagram_link": {
+            "type": "string",
+            "example": "https://instagram.com/example",
+            "description": "The link to the shop's Instagram account"
+          },
+          "facebook_link": {
+            "type": "string",
+            "example": "https://facebook.com/example",
+            "description": "The link to the shop's Facebook account"
+          },
+          "telegram_link": {
+            "type": "string",
+            "example": "https://t.me/example",
+            "description": "The invite link to the shop's Telegram community"
+          },
+          "youtube_link": {
+            "type": "string",
+            "example": "https://youtube.com/example",
+            "description": "The link to the shop's YouTube channel"
+          },
+          "reddit_link": {
+            "type": "string",
+            "example": "https://reddit.com/example",
+            "description": "The link to the shop's SubReddit"
+          },
+          "tiktok_link": {
+            "type": "string",
+            "example": "https://tiktok.com/example",
+            "description": "The link to the shop's TikTok account"
+          },
+          "search_enabled": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Whether or not the shop has dark mode enabled"
+          },
+          "sort_enabled": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Whether or not the shop has product sorting enabled"
+          },
+          "cart_enabled": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Whether or not the shop has the cart system enabled"
+          },
+          "cart_maximum_checkout": {
+            "type": "string",
+            "example": "10000.00",
+            "description": "Set the maximum amount, in your currency, for an order made through the Shopping Cart."
+          },
+          "hide_out_of_stock": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Automatically hide your products when out of stock."
+          },
+          "google_analytics_tracking_id": {
+            "type": "string",
+            "example": "**Terms of Service**\r\nFollow Sellix TOS",
+            "description": "The google analyticd tracking id the shop uses for analytics"
+          },
+          "crisp_website_id": {
+            "type": "string",
+            "example": null,
+            "description": "The crisp website id the shop uses for analytics"
+          },
+          "center_product_titles": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Whether or not the shop's theme centers product titles"
+          },
+          "center_group_titles": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Whether or not the shop's theme centers group titles"
+          },
+          "popup_message": {
+            "type": "string",
+            "example": "Example Popup Message",
+            "description": "This message will be shown to anyone who visits your site. Do not include your Terms of Service here."
+          },
+          "verified": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Whether or not the shop is verified by Sellix"
+          },
+          "on_hold": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Whether or not the shop is on hold"
+          },
+          "terms_of_service": {
+            "type": "string",
+            "example": "Terms of Service",
+            "description": "The terms of service for the shop in MDX"
+          },
+          "primary_color_custom_theme": {
+            "type": "string",
+            "example": null,
+            "description": "The primary color of the shop's custom theme. Value is null if no custom theme is used."
+          },
+          "secondary_color_custom_theme": {
+            "type": "string",
+            "example": null,
+            "description": "The secondary color of the shop's custom theme. Value is null if no custom theme is used."
+          },
+          "primary_font_color_custom_theme": {
+            "type": "string",
+            "example": null,
+            "description": "The primary font color of the shop's custom theme. Value is null if no custom theme is used."
+          },
+          "secondary_font_color_custom_theme": {
+            "type": "string",
+            "example": null,
+            "description": "The secondary font color of the shop's custom theme. Value is null if no custom theme is used."
+          },
+          "custom_embed": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Whether or not the shop uses a custom embed theme. Value is null if no custom theme is used."
+          },
+          "custom_theme": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Whether or not the shop uses a custom storefront theme. Value is null if no custom theme is used."
+          },
+          "font_custom_theme": {
+            "type": "string",
+            "example": null,
+            "description": "The font of the shop's custom storefront theme. Value is null if no custom theme is used."
+          },
+          "style_custom_theme": {
+            "type": "string",
+            "example": null,
+            "description": "The style of the shop's custom storefront theme. Value is null if no custom theme is used."
+          },
+          "embed_style_custom_theme": {
+            "type": "string",
+            "example": null,
+            "description": "The style of the shop's custom embed theme. Value is null if no custom theme is used."
+          },
+          "index_custom_theme": {
+            "type": "string",
+            "example": null,
+            "description": "The index of the shop's active custom storefront theme. Value is null if no custom theme is used."
+          },
+          "product_card_custom_theme": {
+            "type": "string",
+            "example": null,
+            "description": "The product_card of the shop's active custom storefront theme. Value is null if no custom theme is used."
+          },
+          "banner_custom_theme": {
+            "type": "object",
+            "example": null,
+            "description": "The storefront banner of the shop's custom theme. Value is null if no custom theme is used."
+          },
+          "footer_custom_theme": {
+            "type": "object",
+            "example": null,
+            "description": "The storefront footer of the shop's custom theme. Value is null if no custom theme is used."
+          },
+          "background_image_custom_theme": {
+            "type": "object",
+            "example": null,
+            "description": "The storefront background image of the shop's custom theme. Value is null if no custom theme is used."
+          },
+          "logo_custom_theme": {
+            "type": "object",
+            "example": null,
+            "description": "The storefront logo of the shop's custom theme. Value is null if no custom theme is used."
+          },
+          "header_custom_theme": {
+            "type": "object",
+            "example": null,
+            "description": "The storefront header of the shop's custom theme. Value is null if no custom theme is used."
+          },
+          "cards_in_row_custom_theme": {
+            "type": "integer",
+            "example": 4,
+            "description": "The amount of cards to display in a row on the storefront"
+          },
+          "cards_align_custom_theme": {
+            "type": "object",
+            "example": null,
+            "description": "Value is null if no custom theme is used."
+          },
+          "group_card_custom_theme": {
+            "type": "object",
+            "example": null,
+            "description": "Value is null if no custom theme is used."
+          },
+          "card_animation_custom_theme": {
+            "type": "object",
+            "example": null,
+            "description": "Value is null if no custom theme is used."
+          },
+          "light_font_color_custom_theme": {
+            "type": "string",
+            "example": null,
+            "description": "The light mode font color of the shop's custom theme. Value is null if no custom theme is used."
+          },
+          "dark_font_color_custom_theme": {
+            "type": "string",
+            "example": null,
+            "description": "The dark mode font color of the shop's custom theme. Value is null if no custom theme is used."
+          },
+          "light_color_custom_theme": {
+            "type": "string",
+            "example": null,
+            "description": "The light mode accent color of the shop's custom theme. Value is null if no custom theme is used."
+          },
+          "dark_color_custom_theme": {
+            "type": "string",
+            "example": null,
+            "description": "The dark mode accent color of the shop's custom theme. Value is null if no custom theme is used."
+          },
+          "border_color_custom_theme": {
+            "type": "string",
+            "example": null,
+            "description": "The border color of the shop's custom theme. Value is null if no custom theme is used."
+          },
+          "button_color_custom_theme": {
+            "type": "string",
+            "example": null,
+            "description": "The button color of the shop's custom theme. Value is null if no custom theme is used."
+          },
+          "thin_color_custom_theme": {
+            "type": "string",
+            "example": null,
+            "description": "The thin font color of the shop's custom theme. Value is null if no custom theme is used."
+          },
+          "sort_custom_theme": {
+            "type": "string",
+            "enum": ["DEFAULT", "PRICE", "STOCK", "NAME", "TYPE"],
+            "example": "DEFAULT",
+            "description": "The default sorting method for the storefront's custom theme"
+          },
+          "helpspace_client_id": {
+            "type": "string",
+            "example": null,
+            "description": "The helpspace client id of the helpspace account linked to the shop"
+          },
+          "helpspace_token": {
+            "type": "string",
+            "example": "null",
+            "description": "The helpspace token of the helpspace account linked to the shop"
+          },
+          "description_youtube_only": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Show only youtube video for invoice/product description."
+          },
+          "description_skip_default_image": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Skip Default Image for Product Description."
+          },
+          "hide_stock_counter": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "If enabled, the number of how many products are in stock will be removed, we will only show 'In Stock' or 'Out of Stock'."
+          },
+          "image_width": {
+            "type": "integer",
+            "example": 500,
+            "description": "The width of the storefront image"
+          },
+          "image_height": {
+            "type": "integer",
+            "example": 480,
+            "description": "The height of the storefront image"
+          },
+          "default_sort": {
+            "type": "string",
+            "enum": ["DEFAULT", "PRICE", "STOCK", "NAME", "TYPE"],
+            "example": "DEFAULT",
+            "description": "The default sorting method for the storefront"
+          },
+          "description_image": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Whether or not the shop has a description image"
+          },
+          "hide_products_sold": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Hide the products sold counter on your storefront, only your average feedback will be displayed."
+          },
+          "service_date_from": {
+            "type": "string",
+            "enum": ["REGISTRATION_DATE", "FIRST_SALE"],
+            "example": "REGISTRATION_DATE",
+            "description": "Choose whether to display your business starting date from the day of your first sale or the day you have signed up to Sellix."
+          },
+          "cards_type": {
+            "type": "string",
+            "example": "BORDER_OUTLINE",
+            "description": "DEPRECATED: The name of the product image with the file type"
+          },
+          "setup_wizard": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Whether or not the shop has completed the setup wizzard"
+          },
+          "setup_cryptocurrencies": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Whether or not the shop has setup cryptocurrencies"
+          },
+          "notices_banner": {
+            "type": "string",
+            "example": "{\"notices\": []}",
+            "description": "The notices for the shop"
+          },
+          "affiliate_revenue_percent": {
+            "type": "integer",
+            "example": 10,
+            "description": "The percentage of each payment given to affiliates"
+          },
+          "created_at": {
+            "type": "integer",
+            "format": "timestamp",
+            "example": 162857125819,
+            "description": "Timestamp for the creation of the subscription."
+          },
+          "image_name": {
+            "type": "string",
+            "example": "SellixImageName.png",
+            "description": "DEPRECATED: The name of the product image with the file type"
+          },
+          "image_storage": {
+            "type": "string",
+            "example": "PRODUCTS",
+            "description": "Where the image is stored in Sellix's self-hosted CDN."
+          },
+          "cloudflare_image_id": {
+            "$ref": "#/components/schemas/cloudflare_image_id"
+          },
+          "marketplace_verified": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Whether or not the shop is a verified marketplace"
           }
         }
       },
@@ -12707,6 +13257,37 @@
                       "$ref": "#/components/schemas/license"
                     }
                   }
+                },
+                "error": {
+                  "type": "string",
+                  "example": null
+                },
+                "message": {
+                  "type": "string",
+                  "example": null
+                },
+                "env": {
+                  "type": "string",
+                  "example": "production"
+                }
+              }
+            }
+          }
+        }
+      },
+      "shop": {
+        "description": "shop object",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "integer",
+                  "example": 200
+                },
+                "data": {
+                  "$ref": "#/components/schemas/shop_info"
                 },
                 "error": {
                   "type": "string",

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -9284,17 +9284,20 @@
             "properties": {
               "url": {
                 "type": "string",
+                "example": "https://sellix.io/payment/sample-4caac117ca-abeb80",
                 "description": "Sellix hosted payment page."
               },
               "uniqid": {
                 "type": "string",
                 "format": "uuid",
+                "example": "sample-4caac117ca-abeb80",
                 "description": "Unique ID of the invoice created for the payment."
+              },
+              "url_branded": {
+                "type": "string",
+                "example": "https://storename.mysellix.io/invoice/sample-4caac117ca-abeb80",
+                "description": "Sellix hosted payment page with url unique to your shop."
               }
-            },
-            "example": {
-              "url": "https://sellix.io/payment/sample-4caac117ca-abeb80",
-              "uniqid": "sample-4caac117ca-abeb80"
             }
           },
           "error": {
@@ -9303,7 +9306,7 @@
           },
           "message": {
             "type": "string",
-            "example": "<success-message>"
+            "example": null
           },
           "env": {
             "type": "string",
@@ -13004,7 +13007,7 @@
                 "data": {
                   "type": "object",
                   "properties": {
-                    "group": {
+                    "groups": {
                       "type": "array",
                       "items": {
                         "$ref": "#/components/schemas/listedGroup"
@@ -13373,7 +13376,28 @@
                 },
                 "log": {
                   "type": "object",
-                  "example": null
+                  "properties": {
+                    "status": {
+                      "type": "integer",
+                      "example": 200
+                    },
+                    "data": {
+                      "type": "object",
+                      "example": null
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": null
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invoice checkout completed"
+                    },
+                    "env": {
+                      "type": "string",
+                      "example": "production"
+                    }
+                  }
                 }
               }
             }

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -75,6 +75,11 @@
         ],
         "operationId": "getBlacklists",
         "description": "List all the blacklists created on the current shop.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/page"
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/blacklistListing"
@@ -248,6 +253,11 @@
         ],
         "operationId": "getWhitelists",
         "description": "List all the whitelists created on the current shop.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/page"
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/whitelistListing"
@@ -421,6 +431,11 @@
         ],
         "operationId": "getCategories",
         "description": "List all the categories created on the current shop.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/page"
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/categoryListing"
@@ -616,6 +631,11 @@
         ],
         "operationId": "getCoupons",
         "description": "List all the coupons created on the current shop.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/page"
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/couponListing"
@@ -827,6 +847,11 @@
         ],
         "operationId": "feedbackListing",
         "description": "List the feedback received on the current shop.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/page"
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/feedbackListing"
@@ -911,6 +936,11 @@
         ],
         "operationId": "getOrders",
         "description": "List all the orders created on the current shop.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/page"
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/invoiceListing"
@@ -1322,6 +1352,11 @@
         ],
         "operationId": "getProducts",
         "description": "List all the products created on the current shop.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/page"
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/productListing"
@@ -1771,6 +1806,11 @@
         ],
         "operationId": "getQueries",
         "description": "List all the queries created on the current shop.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/page"
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/queryListing"
@@ -2224,6 +2264,11 @@
         ],
         "operationId": "getCustomers",
         "description": "List all the customers created on the current shop.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/page"
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/customers"
@@ -2448,6 +2493,11 @@
         ],
         "operationId": "getSubscriptions",
         "description": "List all the subscriptions created on the current shop.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/page"
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/subscriptions"
@@ -10464,6 +10514,16 @@
         "required": true,
         "example": "sample6978a0e39d",
         "description": "ID of the resource"
+      },
+      "page": {
+        "in": "query",
+        "name": "page",
+        "schema": {
+          "type": "integer"
+        },
+        "required": false,
+        "example": 1,
+        "description": "If pagination is desired, the page to fetch of the response"
       },
       "custom_fields": {
         "in": "query",

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -2958,6 +2958,445 @@
       }
     },
     "schemas": {
+      "aml_wallet": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "example": 987,
+            "description": "AML transaction ID."
+          },
+          "shop_id": {
+            "type": "integer",
+            "example": 987,
+            "description": "Shop ID linked to this AML transaction."
+          },
+          "invoice_id": {
+            "type": "string",
+            "example": "sample-3ddfc9dc3d-ab2e36",
+            "description": "Unique ID of the invoice this AML transaction is linked to."
+          },
+          "origin": {
+            "type": "string",
+            "example": "INVOICE",
+            "description": "Origin of the AML transaction."
+          },
+          "type": {
+            "type": "string",
+            "example": "WALLET",
+            "description": "Type of the AML transaction."
+          },
+          "asset": {
+            "type": "string",
+            "example": "holistic",
+            "description": "Asset of the AML transaction."
+          },
+          "blockchain": {
+            "type": "string",
+            "example": "holistic",
+            "description": "Blockchain of the AML transaction."
+          },
+          "hash": {
+            "type": "string",
+            "example": "bc1qvkwfapml56vvweuvvp7tqvurv2w52asv38u5l3",
+            "description": "AML transaction hash."
+          },
+          "output_type": {
+            "type": "string",
+            "example": null,
+            "description": "AML transaction output type."
+          },
+          "output_address": {
+            "type": "string",
+            "example": null,
+            "description": "AML transaction output address."
+          },
+          "risk_score": {
+            "type": "string",
+            "example": "0.156921",
+            "description": "AML transaction risk score."
+          },
+          "asset_list": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "BTC/bitcoin"
+            ],
+            "description": "AML transaction asset list."
+          },
+          "error": {
+            "type": "string",
+            "example": null,
+            "description": "AML transaction error."
+          },
+          "evaluation_detail": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "source": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "rule_id": {
+                        "type": "string",
+                        "example": "2a380f72-2dcd-4b90-9467-d3c7b6d25dfb",
+                        "description": "Rule ID."
+                      },
+                      "rule_name": {
+                        "type": "string",
+                        "example": "Sanctioned, TF & CSAM",
+                        "description": "Rule name."
+                      },
+                      "risk_score": {
+                        "type": "number",
+                        "format": "double",
+                        "example": 0.014195487896676929,
+                        "description": "Risk score."
+                      },
+                      "matched_elements": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "category": {
+                              "type": "string",
+                              "example": "OFAC Sanctioned Entity",
+                              "description": "Category."
+                            },
+                            "contributions": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "entity": {
+                                    "type": "string",
+                                    "example": "Lazarus Group Harmony Horizon Bridge Exploit - June 2022 (suspected post-Exchange)",
+                                    "description": "Entity."
+                                  },
+                                  "risk_triggers": {
+                                    "type": "object",
+                                    "properties": {
+                                      "country": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "category": {
+                                        "type": "string",
+                                        "example": "OFAC Sanctioned Entity",
+                                        "description": "Category."
+                                      },
+                                      "category_id": {
+                                        "type": "string",
+                                        "example": "8d39eacf-a5c0-4b38-a101-6b3120b84bf9",
+                                        "description": "Category ID."
+                                      },
+                                      "is_sanctioned": {
+                                        "type": "boolean",
+                                        "example": true,
+                                        "description": "Is sanctioned."
+                                      }
+                                    }
+                                  },
+                                  "contribution_value": {
+                                    "type": "object",
+                                    "properties": {
+                                      "usd": {
+                                        "type": "number",
+                                        "format": "double",
+                                        "example": 15.554924625314328,
+                                        "description": "Contribution value in USD."
+                                      }
+                                    }
+                                  },
+                                  "contribution_percentage": {
+                                    "type": "number",
+                                    "format": "double",
+                                    "example": 0.09531445633497328,
+                                    "description": "Contribution percentage."
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "contributions": {
+            "type": "object",
+            "properties": {
+              "source": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "entities": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "example": "Unknown",
+                            "description": "Entity name."
+                          },
+                          "is_vasp": {
+                            "type": "boolean",
+                            "example": null,
+                            "description": "Is a VASP."
+                          },
+                          "actor_id": {
+                            "type": "integer",
+                            "example": -4,
+                            "description": "Actor ID."
+                          },
+                          "category": {
+                            "type": "string",
+                            "example": "Unknown",
+                            "description": "Entity category."
+                          },
+                          "is_primary_entity": {
+                            "type": "boolean",
+                            "example": true,
+                            "description": "Is the primary entity."
+                          }
+                        }
+                      }
+                    },
+                    "contribution_value": {
+                      "type": "object",
+                      "properties": {
+                        "usd": {
+                          "type": "number",
+                          "format": "double",
+                          "example": 8842.310699142721,
+                          "description": "Contribution value in USD."
+                        }
+                      }
+                    },
+                    "contribution_percentage": {
+                      "type": "number",
+                      "format": "double",
+                      "example": 54.1822,
+                      "description": "Contribution percentage."
+                    }
+                  }
+                }
+              },
+              "destination": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "entities": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "example": "Kraken",
+                            "description": "Entity name."
+                          },
+                          "is_vasp": {
+                            "type": "boolean",
+                            "example": true,
+                            "description": "Is a VASP."
+                          },
+                          "actor_id": {
+                            "type": "integer",
+                            "example": 23,
+                            "description": "Actor ID."
+                          },
+                          "category": {
+                            "type": "string",
+                            "example": "Exchange",
+                            "description": "Entity category."
+                          },
+                          "is_primary_entity": {
+                            "type": "boolean",
+                            "example": true,
+                            "description": "Is the primary entity."
+                          }
+                        }
+                      }
+                    },
+                    "contribution_value": {
+                      "type": "object",
+                      "properties": {
+                        "usd": {
+                          "type": "number",
+                          "format": "double",
+                          "example": 14645.819876,
+                          "description": "Contribution value in USD."
+                        }
+                      }
+                    },
+                    "contribution_percentage": {
+                      "type": "number",
+                      "format": "double",
+                      "example": 100,
+                      "description": "Contribution percentage."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "blockchain_info": {
+            "type": "object",
+            "properties": {
+              "cluster": {
+                "type": "object",
+                "properties": {
+                  "inflow_value": {
+                    "type": "object",
+                    "properties": {
+                      "usd": {
+                        "type": "number",
+                        "format": "double",
+                        "example": 16319.573922305124,
+                        "description": "Inflow value in USD."
+                      }
+                    }
+                  },
+                  "outflow_value": {
+                    "type": "object",
+                    "properties": {
+                      "usd": {
+                        "type": "number",
+                        "format": "double",
+                        "example": 14645.819876,
+                        "description": "Inflow value in USD."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "cluster_entities": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "example": "Unknown",
+                  "description": "Entity name."
+                },
+                "is_vasp": {
+                  "type": "boolean",
+                  "example": null,
+                  "description": "Is a VASP."
+                },
+                "actor_id": {
+                  "type": "integer",
+                  "example": -4,
+                  "description": "Actor ID."
+                },
+                "category": {
+                  "type": "string",
+                  "example": "Unknown",
+                  "description": "Entity category."
+                },
+                "is_primary_entity": {
+                  "type": "boolean",
+                  "example": true,
+                  "description": "Is the primary entity."
+                },
+                "is_after_sanction_date": {
+                  "type": "boolean",
+                  "example": false,
+                  "description": "Is after the sanction date."
+                }
+              }
+            }
+          },
+          "risk_score_detail": {
+            "type": "object",
+            "properties": {
+              "source": {
+                "type": "number",
+                "format": "double",
+                "example": 0.15692119477282407,
+                "description": "Source risk score."
+              },
+              "destination": {
+                "type": "number",
+                "format": "double",
+                "example": 0.15692119477282407,
+                "description": "Destination risk score."
+              }
+            }
+          },
+          "created_at": {
+            "type": "integer",
+            "format": "timestamp",
+            "example": 162857125819,
+            "description": "Timestamp for the AML transaction creation date."
+          }
+        }
+      },
+      "approved_address": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "example": 1,
+            "description": "ID of the resource."
+          },
+          "address": {
+            "type": "string",
+            "example": "btcsda312dsad34132dsa",
+            "description": "The crypto address that was approved."
+          },
+          "coin": {
+            "type": "string",
+            "example": "BTC",
+            "description": "The coin of the approved address."
+          },
+          "blockchain": {
+            "$ref": "#/components/schemas/blockchain"
+          },
+          "tx": {
+            "type": "string",
+            "example": "txid",
+            "description": "The transaction ID of the approval."
+          },
+          "recurring_billing_id": {
+            "type": "string",
+            "example": "rec_sample-4caac117ca-abeb80",
+            "description": "The recurring billing ID of the approval."
+          },
+          "allowance": {
+            "type": "number",
+            "example": 0.0001,
+            "description": "The allowance of the approved address."
+          },
+          "updated_at": {
+            "type": "integer",
+            "example": 162857125819,
+            "description": "Timestamp, available if the approved address has been updated."
+          },
+          "created_at": {
+            "type": "integer",
+            "format": "timestamp",
+            "example": 162857125819,
+            "description": "Timestamp, available if the approved address has been created."
+          }
+        }
+      },
       "blacklist": {
         "type": "object",
         "properties": {
@@ -3032,64 +3471,65 @@
           }
         }
       },
-      "whitelist": {
+      "blockchain": {
+        "type": "string",
+        "enum": [
+          "ERC20",
+          "BEP20",
+          "TRC20",
+          "MATIC",
+          "SOL"
+        ],
+        "example": null,
+        "description": "The blockchain of the crypto currency."
+      },
+      "bundle_config": {
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
-            "example": 987,
-            "description": "ID of the resource"
+            "example": 1,
+            "description": "ID of the resource."
           },
           "uniqid": {
             "type": "string",
             "format": "uuid",
             "example": "sample29a0e39d",
-            "description": "Unique ID of the resource, used as reference across the API."
+            "description": "Unique ID of the bundle, used as reference across the API."
           },
           "shop_id": {
             "type": "integer",
-            "example": 987,
-            "description": "The shop ID to which this whitelist belongs."
+            "example": 1,
+            "description": "The shop ID to which this bundle belongs."
           },
-          "type": {
+          "title": {
+            "type": "string",
+            "example": "sampleTitle",
+            "description": "The title of the bundle."
+          },
+          "products": {
+            "type": "string",
+            "example": "PRODUCT_ID_1,PRODUCT_ID_2,PRODUCT_ID_3",
+            "description": "The product IDs of the products in the bundle."
+          },
+          "discount_type": {
             "type": "string",
             "enum": [
-              "EMAIL",
-              "IP",
-              "COUNTRY",
-              "ISP",
-              "ASN",
-              "HOST"
+              "PERCENTAGE",
+              "FIXED"
             ],
-            "example": "EMAIL",
-            "description": "The type of data of this whitelist."
+            "example": "PERCENTAGE",
+            "description": "The type of discount applied to the bundle."
           },
-          "data": {
-            "type": "string",
-            "example": "example@gmail.com",
-            "description": "The value of the whitelist."
-          },
-          "note": {
-            "type": "string",
-            "example": "Admitting known email.",
-            "description": "Additional note provided on whitelist creation."
-          },
-          "created_at": {
-            "type": "integer",
-            "format": "timestamp",
-            "example": 162857125819,
-            "description": "Timestamp for the creation of the whitelist."
+          "discount_amount": {
+            "type": "number",
+            "example": 25,
+            "description": "The amount of the discount applied to the bundle."
           },
           "updated_at": {
-            "type": "integer",
-            "format": "timestamp",
+            "type": "number",
             "example": 162857125819,
-            "description": "Date, available if the whitelist has been edited."
-          },
-          "updated_by": {
-            "type": "integer",
-            "example": 987,
-            "description": "User ID, available if the whitelist has been edited."
+            "description": "Timestamp, available if the bundle has been updated."
           }
         }
       },
@@ -3170,66 +3610,162 @@
           }
         }
       },
-      "group": {
+      "categoryProduct": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "number",
-            "example": 987,
-            "description": "The ID of the resource"
-          },
           "uniqid": {
             "type": "string",
             "format": "uuid",
             "example": "sample29a0e39d",
             "description": "Unique ID of the resource, used as reference across the API."
           },
-          "shop_id": {
+          "price": {
             "type": "number",
-            "example": 987,
-            "description": "The unique identifyer for the shop."
+            "format": "double",
+            "example": "5",
+            "description": "Product price."
+          },
+          "price_display": {
+            "type": "number",
+            "format": "double",
+            "example": "4.5",
+            "description": "Product price in currency."
+          },
+          "price_discount": {
+            "type": "number",
+            "example": "0",
+            "description": "The discount price on the purchased goods."
+          },
+          "currency": {
+            "$ref": "#/components/schemas/currency"
+          },
+          "unlisted": {
+            "type": "boolean",
+            "example": false,
+            "description": "If unlisted is true, the product is not shown in the storefront but can be bought through a direct link."
           },
           "title": {
             "type": "string",
-            "example": "Digital goods to download",
-            "description": "Group title."
+            "example": "Sellix Product",
+            "description": "The product title"
           },
           "image_attachment": {
-            "$ref": "#/components/schemas/image_attachment"
+            "type": "string",
+            "example": null,
+            "description": "DEPRECATED: Unique id of the image attachment for this product."
           },
-          "unlisted": {
-            "type": "number",
+          "description": {
+            "type": "string",
+            "example": "Product description",
+            "description": "Product description."
+          },
+          "quantity_min": {
+            "type": "integer",
+            "minimum": 1,
             "example": 1,
-            "description": "Whether or not the product is unlisted."
+            "description": "Minimum quantity purchasable of this product."
+          },
+          "quantity_max": {
+            "type": "integer",
+            "minimum": -1,
+            "example": -1,
+            "description": "Maximum quantity purchasable of this product."
+          },
+          "quantity_warning": {
+            "type": "integer",
+            "example": "0",
+            "description": "At which product quantity should we send a webhook and email warning the merchant."
+          },
+          "custom_fields": {
+            "$ref": "#/components/schemas/custom_fields_array"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "SERIALS",
+              "FILE",
+              "SERVICE",
+              "DYNAMIC",
+              "INFO_CARD",
+              "SUBSCRIPTION"
+            ],
+            "example": "SUBSCRIPTION",
+            "description": "Product type."
+          },
+          "shop_id": {
+            "type": "number",
+            "example": 987,
+            "description": "The shop ID to which this resource belongs."
+          },
+          "gateways": {
+            "$ref": "#/components/schemas/gateways"
+          },
+          "crypto_confirmations_needed": {
+            "type": "integer",
+            "example": 3,
+            "description": "Minimum number of confirmations for a crypto payment to be accepted."
+          },
+          "private": {
+            "type": "boolean",
+            "example": false,
+            "description": "If private is true, the product is hidden on the storefront and cannot be bought with a direct link."
+          },
+          "stock": {
+            "type": "integer",
+            "example": -1,
+            "description": "Stock of the current product, can be -1 for unlimited stock."
           },
           "sort_priority": {
-            "type": "number",
+            "type": "integer",
             "example": 1,
-            "description": "The priority of the group on the storefront."
+            "description": "Sort order of this product."
+          },
+          "on_hold": {
+            "type": "boolean",
+            "example": false,
+            "description": "If on_hold is true, the product cannot be bought but is shown in the storefront."
           },
           "created_at": {
             "type": "integer",
             "format": "timestamp",
             "example": 162857125819,
-            "description": "Timestamp for the creation of the group."
+            "description": "Timestamp for the creation of the product."
           },
           "updated_at": {
             "type": "integer",
             "format": "timestamp",
             "example": 162857125819,
-            "description": "Date, available if the group has been edited."
+            "description": "Date, available if the product has been edited."
+          },
+          "image_name": {
+            "type": "string",
+            "example": "SellixImageName.png",
+            "description": "DEPRECATED: The name of the product image with the file type"
+          },
+          "image_storage": {
+            "type": "string",
+            "example": "PRODUCTS",
+            "description": "Where the image is stored in Sellix's self-hosted CDN."
+          },
+          "cloudflare_image_id": {
+            "$ref": "#/components/schemas/cloudflare_image_id"
           },
           "category_id": {
             "type": "string",
             "example": "sample29a0e39d",
-            "description": "The category the group is a part of"
+            "description": "The category the product is a part of"
           },
-          "group_id": {
+          "product_id": {
             "type": "string",
             "example": "sample29a0e39d",
-            "description": "The unique identifyer of the current group"
+            "description": "The id of the current product"
           }
         }
+      },
+      "cloudflare_image_id": {
+        "type": "string",
+        "example": "sample-c4f1-4f7c-9a1d-89120ed0c800",
+        "description": "New field containing the cloudflare image ID of this product, replaces image_attachment and image_name. Format https://imagedelivery.net/95QNzrEeP7RU5l5WdbyrKw/<cloudflare_image_id>/<variant_name> where variant_name can be shopItem, avatar, icon, imageAvatarFeedback, public, productImageCart."
       },
       "coupon": {
         "type": "object",
@@ -3520,6 +4056,601 @@
             "type": "integer",
             "example": 1,
             "description": "How many products are present in the products_bound array"
+          }
+        }
+      },
+      "crypto_transaction": {
+        "type": "object",
+        "properties": {
+          "crypto_amount": {
+            "type": "number",
+            "format": "double",
+            "example": 0.014174,
+            "description": "Crypto amount sent in the transaction."
+          },
+          "hash": {
+            "type": "string",
+            "example": "234dB62Q3X9nyqussRSHW5x9rXe7NzyS3hLcwSTtzd9WLWfrHFUtX4KS6DAMyyHnvRgUNiqUvZdw2T9XWJqa8sPW",
+            "description": "Crypto transaction hash."
+          },
+          "confirmations": {
+            "type": "integer",
+            "example": 1,
+            "description": "Crypto transaction confirmations, not updated once the invoice status is COMPLETED or VOIDED."
+          },
+          "created_at": {
+            "type": "integer",
+            "format": "timestamp",
+            "example": 162857125819,
+            "description": "Timestamp for the crypto transaction reception date"
+          },
+          "updated_at": {
+            "type": "integer",
+            "example": 1640673134,
+            "description": "Crypto transaction update date."
+          },
+          "aml_tx": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "example": 987,
+                "description": "AML transaction ID."
+              },
+              "shop_id": {
+                "type": "integer",
+                "example": 987,
+                "description": "Shop ID linked to this AML transaction."
+              },
+              "invoice_id": {
+                "type": "string",
+                "example": "1c7fa9-a277075d5d-6d8431",
+                "description": "Unique ID of the invoice this AML transaction is linked to."
+              },
+              "origin": {
+                "type": "string",
+                "example": "INVOICE",
+                "description": "Origin of the AML transaction."
+              },
+              "type": {
+                "type": "string",
+                "example": "TRANSACTION",
+                "description": "Type of the AML transaction."
+              },
+              "asset": {
+                "type": "string",
+                "example": "holistic",
+                "description": "Asset of the AML transaction."
+              },
+              "blockchain": {
+                "type": "string",
+                "example": "holistic",
+                "description": "Blockchain of the AML transaction."
+              },
+              "hash": {
+                "type": "string",
+                "example": "df6693ca6fe386993ff8496fa297df1f2fcd8ce65bd45468dd1539f16d949ee7",
+                "description": "AML transaction hash."
+              },
+              "output_type": {
+                "type": "string",
+                "example": "address",
+                "description": "AML transaction output type."
+              },
+              "output_address": {
+                "type": "string",
+                "example": "bc1q5k8c3w7js7s56mhremysa7mv9ufsr59eers9ad",
+                "description": "AML transaction output address."
+              },
+              "risk_score": {
+                "type": "string",
+                "example": "0.270000",
+                "description": "AML transaction risk score."
+              },
+              "asset_list": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "example": [
+                  "BTC/bitcoin"
+                ],
+                "description": "AML transaction asset list."
+              },
+              "error": {
+                "type": "string",
+                "example": null,
+                "description": "AML transaction error."
+              },
+              "evaluation_detail": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "example": [],
+                "description": "AML transaction evaluation detail."
+              },
+              "contributions": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "entities": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "example": "Coinbase",
+                            "description": "Entity name."
+                          },
+                          "is_vasp": {
+                            "type": "boolean",
+                            "example": true,
+                            "description": "Is a VASP."
+                          },
+                          "actor_id": {
+                            "type": "integer",
+                            "example": 30,
+                            "description": "Actor ID."
+                          },
+                          "category": {
+                            "type": "string",
+                            "example": "Exchange",
+                            "description": "Entity category."
+                          },
+                          "is_primary_entity": {
+                            "type": "boolean",
+                            "example": true,
+                            "description": "Is the primary entity."
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "blockchain_info": {
+                "type": "object",
+                "properties": {
+                  "address": {
+                    "type": "object",
+                    "properties": {
+                      "has_sent": {
+                        "type": "boolean",
+                        "example": true,
+                        "description": "Has sent."
+                      },
+                      "has_received": {
+                        "type": "boolean",
+                        "example": true,
+                        "description": "Has received."
+                      }
+                    }
+                  },
+                  "transaction": {
+                    "type": "object",
+                    "properties": {
+                      "time": {
+                        "type": "string",
+                        "example": "1975-02-28T22:05:25Z",
+                        "description": "Transaction time."
+                      },
+                      "value": {
+                        "type": "object",
+                        "properties": {
+                          "usd": {
+                            "type": "number",
+                            "format": "double",
+                            "example": 806.035089,
+                            "description": "Transaction value in USD."
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "cluster_entities": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "example": "Unknown",
+                      "description": "Entity name."
+                    },
+                    "is_vasp": {
+                      "type": "boolean",
+                      "example": null,
+                      "description": "Is a VASP."
+                    },
+                    "actor_id": {
+                      "type": "integer",
+                      "example": -4,
+                      "description": "Actor ID."
+                    },
+                    "category": {
+                      "type": "string",
+                      "example": "Unknown",
+                      "description": "Entity category."
+                    },
+                    "is_primary_entity": {
+                      "type": "boolean",
+                      "example": true,
+                      "description": "Is the primary entity."
+                    },
+                    "is_after_sanction_date": {
+                      "type": "boolean",
+                      "example": false,
+                      "description": "Is after the sanction date."
+                    }
+                  }
+                }
+              },
+              "risk_score_detail": {
+                "type": "object",
+                "properties": {
+                  "source": {
+                    "type": "number",
+                    "format": "double",
+                    "example": 0.15692119477282407,
+                    "description": "Source risk score."
+                  },
+                  "destination": {
+                    "type": "number",
+                    "format": "double",
+                    "example": 0.15692119477282407,
+                    "description": "Destination risk score."
+                  }
+                }
+              },
+              "created_at": {
+                "type": "integer",
+                "format": "timestamp",
+                "example": 162857125819,
+                "description": "Timestamp for the AML transaction creation date"
+              }
+            }
+          }
+        }
+      },
+      "currency": {
+        "type": "string",
+        "enum": [
+          "CAD",
+          "HKD",
+          "ISK",
+          "PHP",
+          "DKK",
+          "HUF",
+          "CZK",
+          "GBP",
+          "RON",
+          "SEK",
+          "IDR",
+          "INR",
+          "BRL",
+          "RUB",
+          "HRK",
+          "JPY",
+          "THB",
+          "CHF",
+          "EUR",
+          "MYR",
+          "BGN",
+          "TRY",
+          "CNY",
+          "NOK",
+          "NZD",
+          "ZAR",
+          "USD",
+          "MXN",
+          "SGD",
+          "AUD",
+          "ILS",
+          "KRW",
+          "PLN"
+        ],
+        "example": "EUR",
+        "description": "Available currency."
+      },
+      "custom_fields_array": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "text",
+                "hidden",
+                "number",
+                "largetextbox",
+                "checkbox"
+              ],
+              "example": "checkbox",
+              "description": "Type of the custom field."
+            },
+            "name": {
+              "type": "string",
+              "example": "Read the ToS",
+              "description": "Custom field name displayed to the customer."
+            },
+            "regex": {
+              "type": "string",
+              "example": null,
+              "description": "Regex that the custom field value must match."
+            },
+            "placeholder": {
+              "type": "string",
+              "example": null,
+              "description": "Placeholder for the custom field input."
+            },
+            "default": {
+              "type": "string",
+              "example": null,
+              "description": "Default value if the customer leaves the input empty."
+            },
+            "required": {
+              "type": "boolean",
+              "example": false,
+              "description": "Whether or not this custom field is required to proceed with the purchase."
+            }
+          }
+        }
+      },
+      "custom_fields_object": {
+        "type": "object",
+        "example": {
+          "username": "sellix-user"
+        },
+        "description": "key-value JSON having as key the custom field name and as value the custom field value inserted by the customer. Custom fields can both be used as inputs from the customers but also as metadata for invoices, letting you pass hidden fields for internal referencing."
+      },
+      "customer": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "cst_sample37atm91892",
+            "description": "Customer ID"
+          },
+          "shop_id": {
+            "type": "number",
+            "example": 987,
+            "description": "The shop ID to which this customer belongs."
+          },
+          "email": {
+            "type": "string",
+            "example": "sample@gmail.com",
+            "description": "Customer email"
+          },
+          "name": {
+            "type": "string",
+            "example": "James",
+            "description": "Customer name"
+          },
+          "surname": {
+            "type": "string",
+            "example": "Smith",
+            "description": "Customer surname"
+          },
+          "phone": {
+            "type": "string",
+            "example": 3287261000,
+            "description": "Customer phone"
+          },
+          "phone_country_code": {
+            "type": "string",
+            "example": "IT",
+            "description": "Customer phone country code"
+          },
+          "country_code": {
+            "type": "string",
+            "example": "IT",
+            "description": "Customer country code"
+          },
+          "street_address": {
+            "type": "string",
+            "example": "St. Rome 404",
+            "description": "Customer street address"
+          },
+          "additional_address_info": {
+            "type": "string",
+            "example": null,
+            "description": "Customer street address additional info"
+          },
+          "city": {
+            "type": "string",
+            "example": "Rome",
+            "description": "Customer city"
+          },
+          "postal_code": {
+            "type": "string",
+            "example": 987,
+            "description": "Customer postal code"
+          },
+          "state": {
+            "type": "string",
+            "example": "Italy",
+            "description": "Customer state"
+          },
+          "affiliate_revenue": {
+            "type": "string",
+            "example": "0.00",
+            "description": "Revenue customer has recieved from the affiliate program"
+          },
+          "affiliate_revenue_currency": {
+            "type": "string",
+            "example": "EUR",
+            "description": "The currency the customer gets reimbursed in for the affiliate program"
+          },
+          "created_at": {
+            "type": "integer",
+            "format": "timestamp",
+            "example": 162857125819,
+            "description": "Timestamp for the creation of the customer."
+          },
+          "subscriptions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/subscriptionListing"
+            }
+          },
+          "invoices": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/miniInvoice"
+            }
+          }
+        }
+      },
+      "fee_breakdown": {
+        "type": "object",
+        "properties": {
+          "service_fee": {
+            "type": "object",
+            "properties": {
+              "amount": {
+                "type": "number",
+                "example": 0.5,
+                "description": "The amount of the service fee."
+              },
+              "currency": {
+                "$ref": "#/components/schemas/currency"
+              },
+              "breakdown": {
+                "type": "object",
+                "properties": {
+                  "flat": {
+                    "type": "object",
+                    "properties": {
+                      "amount": {
+                        "type": "number",
+                        "example": 0.5,
+                        "description": "The amount of the service fee."
+                      },
+                      "currency": {
+                        "$ref": "#/components/schemas/currency"
+                      }
+                    }
+                  },
+                  "percentage": {
+                    "type": "object",
+                    "properties": {
+                      "plan": {
+                        "type": "string",
+                        "example": "GATEWAY_NO_FEES",
+                        "description": "The plan of the service fee."
+                      },
+                      "value": {
+                        "type": "number",
+                        "example": "0",
+                        "description": "The amount of the service fee."
+                      },
+                      "amount": {
+                        "type": "number",
+                        "example": "0",
+                        "description": "The amount of the service fee."
+                      },
+                      "currency": {
+                        "$ref": "#/components/schemas/currency"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "aml_analysis": {
+            "type": "object",
+            "properties": {
+              "amount": {
+                "type": "number",
+                "example": 1,
+                "description": "The amount of the service fee."
+              },
+              "currency": {
+                "$ref": "#/components/schemas/currency"
+              },
+              "breakdown": {
+                "type": "object",
+                "properties": {
+                  "flat": {
+                    "type": "object",
+                    "properties": {
+                      "amount": {
+                        "type": "number",
+                        "example": "0",
+                        "description": "The amount of the service fee."
+                      },
+                      "currency": {
+                        "$ref": "#/components/schemas/currency"
+                      }
+                    }
+                  },
+                  "percentage": {
+                    "type": "object",
+                    "properties": {
+                      "amount": {
+                        "type": "number",
+                        "example": 50,
+                        "description": "The amount of the service fee."
+                      },
+                      "currency": {
+                        "$ref": "#/components/schemas/currency"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "platform_fee": {
+            "type": "object",
+            "properties": {
+              "amount": {
+                "type": "number",
+                "example": 1,
+                "description": "The amount of the service fee."
+              },
+              "currency": {
+                "$ref": "#/components/schemas/currency"
+              },
+              "breakdown": {
+                "type": "object",
+                "properties": {
+                  "flat": {
+                    "type": "object",
+                    "properties": {
+                      "amount": {
+                        "type": "number",
+                        "example": 1,
+                        "description": "The amount of the service fee."
+                      },
+                      "currency": {
+                        "$ref": "#/components/schemas/currency"
+                      }
+                    }
+                  },
+                  "percentage": {
+                    "type": "object",
+                    "properties": {
+                      "amount": {
+                        "type": "number",
+                        "example": "0",
+                        "description": "The amount of the service fee."
+                      },
+                      "currency": {
+                        "$ref": "#/components/schemas/currency"
+                      }
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       },
@@ -4312,772 +5443,192 @@
           }
         }
       },
-      "categoryProduct": {
-        "type": "object",
-        "properties": {
-          "uniqid": {
-            "type": "string",
-            "format": "uuid",
-            "example": "sample29a0e39d",
-            "description": "Unique ID of the resource, used as reference across the API."
-          },
-          "price": {
-            "type": "number",
-            "format": "double",
-            "example": "5",
-            "description": "Product price."
-          },
-          "price_display": {
-            "type": "number",
-            "format": "double",
-            "example": "4.5",
-            "description": "Product price in currency."
-          },
-          "price_discount": {
-            "type": "number",
-            "example": "0",
-            "description": "The discount price on the purchased goods."
-          },
-          "currency": {
-            "$ref": "#/components/schemas/currency"
-          },
-          "unlisted": {
-            "type": "boolean",
-            "example": false,
-            "description": "If unlisted is true, the product is not shown in the storefront but can be bought through a direct link."
-          },
-          "title": {
-            "type": "string",
-            "example": "Sellix Product",
-            "description": "The product title"
-          },
-          "image_attachment": {
-            "type": "string",
-            "example": null,
-            "description": "DEPRECATED: Unique id of the image attachment for this product."
-          },
-          "description": {
-            "type": "string",
-            "example": "Product description",
-            "description": "Product description."
-          },
-          "quantity_min": {
-            "type": "integer",
-            "minimum": 1,
-            "example": 1,
-            "description": "Minimum quantity purchasable of this product."
-          },
-          "quantity_max": {
-            "type": "integer",
-            "minimum": -1,
-            "example": -1,
-            "description": "Maximum quantity purchasable of this product."
-          },
-          "quantity_warning": {
-            "type": "integer",
-            "example": "0",
-            "description": "At which product quantity should we send a webhook and email warning the merchant."
-          },
-          "custom_fields": {
-            "$ref": "#/components/schemas/custom_fields_array"
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "SERIALS",
-              "FILE",
-              "SERVICE",
-              "DYNAMIC",
-              "INFO_CARD",
-              "SUBSCRIPTION"
-            ],
-            "example": "SUBSCRIPTION",
-            "description": "Product type."
-          },
-          "shop_id": {
-            "type": "number",
-            "example": 987,
-            "description": "The shop ID to which this resource belongs."
-          },
-          "gateways": {
-            "$ref": "#/components/schemas/gateways"
-          },
-          "crypto_confirmations_needed": {
-            "type": "integer",
-            "example": 3,
-            "description": "Minimum number of confirmations for a crypto payment to be accepted."
-          },
-          "private": {
-            "type": "boolean",
-            "example": false,
-            "description": "If private is true, the product is hidden on the storefront and cannot be bought with a direct link."
-          },
-          "stock": {
-            "type": "integer",
-            "example": -1,
-            "description": "Stock of the current product, can be -1 for unlimited stock."
-          },
-          "sort_priority": {
-            "type": "integer",
-            "example": 1,
-            "description": "Sort order of this product."
-          },
-          "on_hold": {
-            "type": "boolean",
-            "example": false,
-            "description": "If on_hold is true, the product cannot be bought but is shown in the storefront."
-          },
-          "created_at": {
-            "type": "integer",
-            "format": "timestamp",
-            "example": 162857125819,
-            "description": "Timestamp for the creation of the product."
-          },
-          "updated_at": {
-            "type": "integer",
-            "format": "timestamp",
-            "example": 162857125819,
-            "description": "Date, available if the product has been edited."
-          },
-          "image_name": {
-            "type": "string",
-            "example": "SellixImageName.png",
-            "description": "DEPRECATED: The name of the product image with the file type"
-          },
-          "image_storage": {
-            "type": "string",
-            "example": "PRODUCTS",
-            "description": "Where the image is stored in Sellix's self-hosted CDN."
-          },
-          "cloudflare_image_id": {
-            "$ref": "#/components/schemas/cloudflare_image_id"
-          },
-          "category_id": {
-            "type": "string",
-            "example": "sample29a0e39d",
-            "description": "The category the product is a part of"
-          },
-          "product_id": {
-            "type": "string",
-            "example": "sample29a0e39d",
-            "description": "The id of the current product"
-          }
-        }
+      "gateways": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "enum": [
+            "PAYPAL",
+            "STRIPE",
+            "SKRILL",
+            "PERFECT_MONEY",
+            "CASH_APP",
+            "BINANCE",
+            "BITCOIN",
+            "LITECOIN",
+            "ETHEREUM",
+            "BITCOIN_CASH",
+            "NANO",
+            "MONERO",
+            "SOLANA",
+            "RIPPLE",
+            "BINANCE_COIN",
+            "USDC:ERC20",
+            "USDC:BEP20",
+            "USDC:MATIC",
+            "USDC:SOL",
+            "USDT:ERC20",
+            "USDT:BEP20",
+            "USDT:MATIC",
+            "USDT:SOL",
+            "USDT:TRC20",
+            "TRON",
+            "BITCOIN_LN",
+            "CONCORDIUM",
+            "POLYGON",
+            "PEPE:ERC20",
+            "DAI:ERC20",
+            "DAI:BEP20",
+            "DAI:MATIC",
+            "WETH:BEP20",
+            "WETH:MATIC",
+            "APE:ERC20",
+            "APE:MATIC",
+            "SHIB:ERC20",
+            "SHIB:BEP20",
+            "SHIB:MATIC",
+            "USDC_NATIVE:MATIC",
+            "DOGECOIN",
+            "PYTH:SOL",
+            "BONK:SOL",
+            "JUP:SOL",
+            "JITO:SOL",
+            "WEN:SOL",
+            "RENDER:SOL",
+            "MOBILE:SOL",
+            "HNT:SOL"
+          ]
+        },
+        "example": [
+          "PAYPAL",
+          "STRIPE",
+          "BITCOIN"
+        ]
       },
-      "product": {
+      "gateway_fees": {
         "type": "object",
         "properties": {
           "id": {
-            "type": "number",
-            "example": 987,
-            "description": "Unique ID of the resource, used as reference across the API."
-          },
-          "uniqid": {
-            "type": "string",
-            "format": "uuid",
-            "example": "sample29a0e39d",
-            "description": "Unique ID of the resource, used as reference across the API."
-          },
-          "slug": {
-            "type": "string",
-            "example": "digital-good-to-download",
-            "description": "The slug used to navigate to the product page on a storefront."
+            "type": "integer",
+            "example": 1,
+            "description": "ID of the resource."
           },
           "shop_id": {
-            "type": "number",
-            "example": 987,
-            "description": "The shop ID to which this resource belongs."
+            "type": "integer",
+            "example": 1,
+            "description": "The shop ID to which this gateway fee belongs."
           },
-          "type": {
+          "gateway": {
             "type": "string",
             "enum": [
-              "SERIALS",
-              "FILE",
-              "SERVICE",
-              "DYNAMIC",
-              "INFO_CARD",
-              "SUBSCRIPTION"
-            ],
-            "example": "SUBSCRIPTION",
-            "description": "Product type."
-          },
-          "subtype": {
-            "type": "string",
-            "enum": [
-              "SERIALS",
-              "FILE",
-              "SERVICE",
-              "DYNAMIC"
+              "PAYPAL",
+              "STRIPE",
+              "SKRILL",
+              "PERFECT_MONEY",
+              "CASH_APP",
+              "BINANCE",
+              "BITCOIN",
+              "LITECOIN",
+              "ETHEREUM",
+              "BITCOIN_CASH",
+              "NANO",
+              "MONERO",
+              "SOLANA",
+              "RIPPLE",
+              "BINANCE_COIN",
+              "USDC:ERC20",
+              "USDC:BEP20",
+              "USDC:MATIC",
+              "USDC:SOL",
+              "USDT:ERC20",
+              "USDT:BEP20",
+              "USDT:MATIC",
+              "USDT:SOL",
+              "USDT:TRC20",
+              "TRON",
+              "BITCOIN_LN",
+              "CONCORDIUM",
+              "POLYGON",
+              "PEPE:ERC20",
+              "DAI:ERC20",
+              "DAI:BEP20",
+              "DAI:MATIC",
+              "WETH:BEP20",
+              "WETH:MATIC",
+              "APE:ERC20",
+              "APE:MATIC",
+              "SHIB:ERC20",
+              "SHIB:BEP20",
+              "SHIB:MATIC",
+              "USDC_NATIVE:MATIC",
+              "DOGECOIN",
+              "PYTH:SOL",
+              "BONK:SOL",
+              "JUP:SOL",
+              "JITO:SOL",
+              "WEN:SOL",
+              "RENDER:SOL",
+              "MOBILE:SOL",
+              "HNT:SOL"
             ],
             "example": null,
-            "description": "Product subtype, can be used only with type SUBSCRIPTION."
+            "description": "The gateway of the gateway fee."
           },
-          "title": {
-            "type": "string",
-            "example": "Digital good to download",
-            "description": "Product title."
+          "percent_amount": {
+            "type": "number",
+            "example": 3,
+            "description": "The percent amount of the gateway fee."
           },
-          "currency": {
+          "fixed_amount": {
+            "type": "number",
+            "example": "0",
+            "description": "The fixed amount of the gateway fee."
+          },
+          "fixed_currency": {
             "$ref": "#/components/schemas/currency"
           },
-          "pay_what_you_want": {
-            "type": "integer",
-            "enum": [0, 1],
-            "example": 1,
-            "description": "Whether or not pay-what-you-want pricing is enabled."
-          },
-          "price": {
-            "type": "number",
-            "format": "double",
-            "example": 4.00,
-            "description": "Product price."
-          },
-          "price_display": {
-            "type": "number",
-            "format": "double",
-            "example": 5.00,
-            "description": "Product price in currency."
-          },
-          "price_discount": {
-            "type": "number",
-            "format": "double",
-            "example": 1.00,
-            "description": "The discount price on the purchased goods."
-          },
-          "affiliate_revenue_percent": {
-            "type": "number",
-            "example": 15,
-            "description": "The percentage of revenue to give to affiliates. -1 for disabled, 0 for default (10%), other number for a custom percent."
-          },
-          "price_variants": {
-            "type": "object",
-            "example": null,
-            "description": "Variants in pricing for the product."
-          },
-          "description": {
-            "type": "string",
-            "example": "Product description",
-            "description": "Product description."
-          },
-          "licensing_enabled": {
-            "type": "integer", 
-            "enum": [0, 1],
-            "example": 1,
-            "description": "Whether product licenses are generated on successful payments"
-          },
-          "license_period": {
-            "type": "integer",
-            "example": 7,
-            "description": "Amount in days that licenses will be valid for"
-          },
-          "image_attachment": {
-            "$ref": "#/components/schemas/image_attachment"
-          },
-          "file_attachment": {
-            "type": "string",
-            "example": null,
-            "description": "Unique id of the file attachment for this product if the product type is FILE."
-          },
-          "youtube_link": {
-            "type": "string",
-            "example": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-            "description": "The url for the YouTube video of the product"
-          },
-          "volume_discounts": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "enum": [
-                    "PERCENTAGE",
-                    "FIXED"
-                  ],
-                  "example": "PERCENTAGE",
-                  "description": "Whether the discount value is a percentage or a fixed amount."
-                },
-                "value": {
-                  "type": "integer",
-                  "example": 5,
-                  "description": "Value of a percentage or fixed discount."
-                },
-                "quantity": {
-                  "type": "integer",
-                  "example": 10,
-                  "description": "How much of this product needs to be purchased in order to be eligible for this volume discount."
-                }
-              }
-            },
-            "description": "Array of volume discounts."
-          },
-          "recurring_interval": {
+          "active_type": {
             "type": "string",
             "enum": [
-              "DAY",
-              "WEEK",
-              "MONTH",
-              "YEAR"
+              "PERCENT",
+              "FIXED"
             ],
-            "example": "MONTH",
-            "description": "At which frequency the customer is billed for product type SUBSCRIPTION."
-          },
-          "recurring_interval_count": {
-            "type": "integer",
-            "example": 1,
-            "description": "How many recurring_interval before the customer is billed for product type SUBSCRIPTION."
-          },
-          "trial_period": {
-            "type": "integer",
-            "example": "0",
-            "description": "Defines a trial period before billing the customer for product type SUBSCRIPTION."
-          },
-          "paypal_product_id": {
-            "type": "string",
-            "example": null,
-            "description": "When a product SUBSCRIPTION is created and the gateway PAYPAL chosen, a PayPal product is automatically created on the connected account."
-          },
-          "paypal_plan_id": {
-            "type": "string",
-            "example": null,
-            "description": "When a product SUBSCRIPTION is created and the gateway PAYPAL chosen, a PayPal plan is automatically created on the connected account."
-          },
-          "stripe_price_id": {
-            "type": "string",
-            "example": "price_sample2X7rAeMb7AM5APEU",
-            "description": "When a product SUBSCRIPTION is created and the gateway STRIPE chosen, a Stripe price is automatically created on the connected account."
-          },
-          "discord_integration": {
-            "type": "integer",
-            "enum": [0, 1],
-            "example": 1,
-            "description": "Whether or not the discord integeration is enabled for this product."
-          },
-          "discord_optional": {
-            "type": "integer",
-            "enum": [0, 1],
-            "example": 1,
-            "description": "Whether or not the discord integration is optional."
-          },
-          "discord_set_role": {
-            "type": "integer",
-            "enum": [0, 1],
-            "example": 1,
-            "description": "Whether to give users a role when added to the discord server."
-          },
-          "discord_server_id": {
-            "type": "string",
-            "example": "742768752180854827",
-            "description": "The id of the discord server the bot will add users to."
-          },
-          "discord_role_id": {
-            "type": "number",
-            "example": "742772275698335765",
-            "description": "The role to give users when added by the discord integration."
-          },
-          "discord_remove_role": {
-            "type": "integer",
-            "enum": [0, 1],
-            "example": "0",
-            "description": "Whether to remove a role from the user when added to the discord server."
-          },
-          "quantity_min": {
-            "type": "integer",
-            "minimum": 1,
-            "example": 1,
-            "description": "Minimum quantity purchasable of this product."
-          },
-          "quantity_max": {
-            "type": "integer",
-            "minimum": -1,
-            "example": -1,
-            "description": "Maximum quantity purchasable of this product."
-          },
-          "quantity_warning": {
-            "type": "integer",
-            "example": "0",
-            "description": "At which product quantity should we send a webhook and email warning the merchant."
-          },
-          "gateways": {
-            "$ref": "#/components/schemas/gateways"
-          },
-          "custom_fields": {
-            "$ref": "#/components/schemas/custom_fields_array"
-          },
-          "crypto_confirmations_needed": {
-            "type": "integer",
-            "example": 3,
-            "description": "Minimum number of confirmations for a crypto payment to be accepted."
-          },
-          "max_risk_level": {
-            "type": "integer",
-            "example": 85,
-            "description": "For PAYPAL and STRIPE, maximum risk level to accept payments in order to block fraud attempts."
-          },
-          "block_vpn_proxies": {
-            "type": "boolean",
-            "example": true,
-            "description": "Block VPN and Proxy purchases if the gateway is PAYPAL or STRIPE."
-          },
-          "delivery_text": {
-            "type": "string",
-            "example": "Thank you for purchasing this subscription!",
-            "description": "The text to be delivered to the customer after payment"
-          },
-          "delivery_time": {
-            "type": "integer",
-            "example": 162857125819,
-            "description": "The timestamp for when the invoice was delivered"
-          },
-          "service_text": {
-            "type": "string",
-            "example": "In order to get you services, please contact us at..",
-            "description": "The text to be delivered to the customer after payment for a service"
-          },
-          "stock_delimiter": {
-            "type": "string",
-            "example": ",",
-            "description": "How to delimit the stock if product type is SERIALS, for example with stock_delimiter \",\" and serials value first,second; the stock would have two different serials \"first\" and \"second\"."
-          },
-          "stock": {
-            "type": "integer",
-            "example": -1,
-            "description": "Stock of the current product, can be -1 for unlimited stock."
-          },
-          "dynamic_webhook": {
-            "type": "object",
-            "example": null
-          },
-          "bestseller": {
-            "type": "number",
-            "example": "0",
-            "description": "DEPRECATED"
-          },
-          "sort_priority": {
-            "type": "integer",
-            "example": 1,
-            "description": "Sort order of this product."
-          },
-          "unlisted": {
-            "type": "boolean",
-            "example": false,
-            "description": "If unlisted is true, the product is not shown in the storefront but can be bought through a direct link."
-          },
-          "on_hold": {
-            "type": "boolean",
-            "example": false,
-            "description": "If on_hold is true, the product cannot be bought but is shown in the storefront."
-          },
-          "terms_of_service": {
-            "type": "string",
-            "example": null,
-            "description": "Text containing the product's terms of service."
-          },
-          "warranty": {
-            "type": "integer",
-            "example": 86400,
-            "description": "Time, in seconds, of how much the warranty for this product lasts."
-          },
-          "warranty_text": {
-            "type": "string",
-            "example": "This warranty covers..",
-            "description": "Clear explanation of what the warranty covers."
-          },
-          "watermark_enabled": {
-            "type": "number",
-            "example": 1,
-            "description": "Whether sellix should add a watermark to your product image."
-          },
-          "watermark_text": {
-            "type": "string",
-            "example": "Sellix",
-            "description": "The watermark to add to the product image."
-          },
-          "redirect_link": {
-            "type": "string",
-            "example": "https://sellix.io",
-            "description": "The url to redirect a customer to on successful payment"
-          },
-          "label_singular": {
-            "type": "string",
-            "example": null
-          },
-          "label_plural": {
-            "type": "string",
-            "example": null
-          },
-          "private": {
-            "type": "boolean",
-            "example": false,
-            "description": "If private is true, the product is hidden on the storefront and cannot be bought with a direct link."
-          },
-          "created_at": {
-            "type": "integer",
-            "format": "timestamp",
-            "example": 162857125819,
-            "description": "Timestamp for the creation of the product."
+            "example": "PERCENT",
+            "description": "The active type of the gateway fee."
           },
           "updated_at": {
-            "type": "integer",
-            "format": "timestamp",
-            "example": 162857125819,
-            "description": "Date, available if the product has been edited."
-          },
-          "updated_by": {
-            "type": "integer",
-            "example": 987,
-            "description": "User ID, available if the product has been edited."
-          },
-          "marketplace_category_id": {
             "type": "string",
-            "example": "0",
-            "description": "The category ID the product is a part of"
+            "format": "date-time",
+            "example": "1975-02-28 15:05:25",
+            "description": "DateTime, available if the gateway fee has been updated."
           },
-          "telegram_group_id": {
+          "created_at": {
             "type": "string",
-            "example": "none",
-            "description": "The Telegram group ID"
+            "format": "date-time",
+            "example": "1975-02-28 15:05:25",
+            "description": "DateTime, available if the gateway fee has been created."
           },
-          "telegram_integration": {
-            "type": "integer",
-            "enum": [0, 1],
-            "example": 1,
-            "description": "Whether or not the Telegram integration is enabled"
-          },
-          "telegram_optional": {
-            "type": "integer",
-            "enum": [0, 1],
-            "example": 1,
-            "description": "Whether or not the Telegram integration is optional"
-          },
-          "name": {
-            "type": "string",
-            "example": "Sellix",
-            "description": "The name of the product"
-          },
-          "image_name": {
-            "type": "string",
-            "example": "SellixImageName.png",
-            "description": "DEPRECATED: The name of the product image with the file type"
-          },
-          "image_storage": {
-            "type": "string",
-            "example": "PRODUCTS",
-            "description": "Where the image is stored in Sellix's self-hosted CDN."
-          },
-          "cloudflare_image_id": {
-            "$ref": "#/components/schemas/cloudflare_image_id"
-          },
-          "image_attachments": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/image_attachment"
-            }
-          },
-          "feedback": {
-            "type": "object",
-            "properties": {
-              "total": {
-                "type": "integer",
-                "example": 10,
-                "description": "Count of all the feedback."
-              },
-              "positive": {
-                "type": "integer",
-                "example": 8,
-                "description": "Count of positive feedback."
-              },
-              "neutral": {
-                "type": "integer",
-                "example": 1,
-                "description": "Count of neutral feedback."
-              },
-              "negative": {
-                "type": "integer",
-                "example": 1,
-                "description": "Count of negative feedback."
-              },
-              "numbers": {
-                "type": "object",
-                "additionalProperties": {
-                  "type": "integer"
-                },
-                "example": {
-                  "5": 6,
-                  "4": 2,
-                  "3": 1,
-                  "1": 1
-                }
-              },
-              "list": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "score": {
-                      "type": "number",
-                      "example": 5
-                    },
-                    "message": {
-                      "type": "string",
-                      "example": "Nice product!"
-                    },
-                    "reply": {
-                      "type": "string",
-                      "example": "Thank you for the feedback."
-                    },
-                    "created_at": {
-                      "type": "integer",
-                      "format": "timestamp",
-                      "example": 162857125819,
-                      "description": "Timestamp for the creation of the feedback."
-                    },
-                    "updated_at": {
-                      "type": "number",
-                      "example": 162857125819
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "categories": {
-            "type": "array",
-            "items": {
-              "properties": {
-                "title": {
-                  "type": "string",
-                  "example": "Test Category",
-                  "description": "The title of the category"
-                },
-                "uniqid": {
-                  "type": "string",
-                  "example": "sample29a0e39d",
-                  "description": "The unique id of the category"
-                }
-              }
-            }
-          },
-          "payment_gateways_fees": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "integer",
-                  "example": 987
-                },
-                "shop_id": {
-                  "type": "integer",
-                  "example": 987,
-                  "description": "The shop ID to which this resource belongs."
-                },
-                "gateway": {
-                  "type": "string",
-                  "enum": [
-                    "PAYPAL",
-                    "STRIPE",
-                    "SKRILL",
-                    "PERFECT_MONEY",
-                    "CASH_APP",
-                    "BINANCE",
-                    "BITCOIN",
-                    "LITECOIN",
-                    "ETHEREUM",
-                    "BITCOIN_CASH",
-                    "NANO",
-                    "MONERO",
-                    "SOLANA",
-                    "RIPPLE",
-                    "BINANCE_COIN",
-                    "USDC:ERC20",
-                    "USDC:BEP20",
-                    "USDC:MATIC",
-                    "USDC:SOL",
-                    "USDT:ERC20",
-                    "USDT:BEP20",
-                    "USDT:MATIC",
-                    "USDT:SOL",
-                    "USDT:TRC20",
-                    "TRON",
-                    "BITCOIN_LN",
-                    "CONCORDIUM",
-                    "POLYGON",
-                    "PEPE:ERC20",
-                    "DAI:ERC20",
-                    "DAI:BEP20",
-                    "DAI:MATIC",
-                    "WETH:BEP20",
-                    "WETH:MATIC",
-                    "APE:ERC20",
-                    "APE:MATIC",
-                    "SHIB:ERC20",
-                    "SHIB:BEP20",
-                    "SHIB:MATIC",
-                    "USDC_NATIVE:MATIC",
-                    "DOGECOIN",
-                    "PYTH:SOL",
-                    "BONK:SOL",
-                    "JUP:SOL",
-                    "JITO:SOL",
-                    "WEN:SOL",
-                    "RENDER:SOL",
-                    "MOBILE:SOL",
-                    "HNT:SOL"
-                  ],
-                  "example": "STRIPE"
-                },
-                "percent_amount": {
-                  "type": "integer",
-                  "example": -5
-                },
-                "fixed_amount": {
-                  "type": "integer",
-                  "example": "0"
-                },
-                "fixed_currency": {
-                  "$ref": "#/components/schemas/currency"
-                },
-                "active_type": {
-                  "type": "string",
-                  "enum": ["PERCENT", "FIXED"],
-                  "example": "null",
-                  "description": "DEPRECATED"
-                },
-                "updated_at": {
-                  "type": "string",
-                  "example": "1970-01-01 00:00:00"
-                },
-                "created_at": {
-                  "type": "string",
-                  "format": "date-time",
-                  "example": "1975-02-28 00:00:00",
-                  "description": "Datetime for the creation of the resource"
-                }
-              }
-            }
-          },
-          "price_conversions": {
+          "conversions": {
             "type": "object", 
             "properties": {
               "AUD": {
                 "type": "number",
-                "example": 92.08,
+                "example": 12.43,
                 "description": "The price of the product variant in AUD."
               },
               "BGN": {
                 "type": "number",
-                "example": 108.62,
+                "example": 14.66,
                 "description": "The price of the product variant in BGN."
               },
               "BRL": {
                 "type": "number",
-                "example": 300.17,
+                "example": 40.52,
                 "description": "The price of the product variant in BRL."
               },
               "ZAR": {
                 "type": "number",
-                "example": 1143.49,
+                "example": 154.37,
                 "description": "The price of the product variant in ZAR."
               },
               "crypto": {
@@ -5085,181 +5636,38 @@
                 "properties": {
                   "APE": {
                     "type": "string",
-                    "example": "31.0607029506",
+                    "example": "0.00435",
                     "description": "The price of the product variant in APE."
                   },
                   "BCH": {
                     "type": "string",
-                    "example": "0.1271212408",
+                    "example": "1.062",
                     "description": "The price of the product variant in BCH."
                   },
                   "BNB": {
                     "type": "string",
-                    "example": "0.1067436987",
+                    "example": "1.265",
                     "description": "The price of the product variant in BNB."
                   },
                   "USDC_NATIVE": {
                     "type": "string",
-                    "example": "60.0000000000",
+                    "example": "0.00225",
                     "description": "The price of the product variant in USDC_NATIVE."
                   }
                 },
                 "description": "A list of the price of the product variant in various cryptocurrencies."
               }
             }
-          },
-          "country_regulations": {
-            "type": "string",
-            "example": "IT",
-            "description": "The country ISO code that the business is located in"
-          },
-          "available_stripe_apm": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string",
-                "example": "afterpay_clearpay"
-              },
-              "name": {
-                "type": "string",
-                "example": "Afterpay and Clearpay"
-              }
-            }
-          },
-          "serials": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "example": []
-          },
-          "webhooks": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "example": []
-          },
-          "theme": {
-            "type": "string",
-            "example": "dark",
-            "description": "The current theme enabled on the Sellix storefront"
-          },
-          "dark_mode": {
-            "type": "integer",
-            "enum": [0, 1],
-            "example": 1,
-            "description": "Whether or not dark mode is enabled on the Sellix storefront"
-          },
-          "vat_percentage": {
-            "type": "string",
-            "example": "0.00",
-            "description": "The VAR percentage set for the store"
-          },
-          "tax_details": {
-            "type": "object",
-            "properties": {
-              "vat_percentage": {
-                "type": "string",
-                "example": "0.00"
-              },
-              "tax_configuration": {
-                "type": "string",
-                "example": "NONE"
-              },
-              "tax_configuration_data": {
-                "type": "array",
-                "example": []
-              },
-              "display_tax_on_storefront": {
-                "type": "integer",
-                "enum": [0, 1],
-                "example": 0
-              },
-              "display_tax_custom_fields": {
-                "type": "integer",
-                "enum": [0, 1],
-                "example": 0
-              },
-              "validation_only_for_companies": {
-                "type": "integer",
-                "enum": [0, 1],
-                "example": 1
-              },
-              "validate_vat_number": {
-                "type": "integer",
-                "enum": [0, 1],
-                "example": 0
-              },
-              "prices_tax_inclusive": {
-                "type": "integer",
-                "enum": [0, 1],
-                "example": 0
-              }
-            }
-          },
-          "image_attachment_info": {
-            "$ref": "#/components/schemas/image_attachment"
-          },
-          "average_score": {
-            "type": "string",
-            "example": "5.0000",
-            "description": "The average rating of the product."
-          },
-          "sold_count": {
-            "type": "number",
-            "example": 236,
-            "description": "The amount of sales for the product."
-          },
-          "addons": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "integer",
-                  "example": 987
-                },
-                "uniqid": {
-                  "type": "string",
-                  "example": "sample29a0e39d"
-                },
-                "shop_id": {
-                  "type": "integer",
-                  "example": 987,
-                  "description": "The shop ID to which this resource belongs."
-                },
-                "product_types": {
-                  "type": "array",
-                  "example": null
-                },
-                "title": {
-                  "type": "string",
-                  "example": "Sellix"
-                },
-                "description": {
-                  "type": "string",
-                  "example": "A Sellix product description"
-                },
-                "price": {
-                  "type": "string",
-                  "example": "1.00"
-                },
-                "currency": {
-                  "$ref": "#/components/schemas/currency"
-                }
-              }
-            }
           }
         }
       },
-      "listedProduct": {
+      "group": {
         "type": "object",
         "properties": {
           "id": {
             "type": "number",
             "example": 987,
-            "description": "Unique ID of the resource, used as reference across the API."
+            "description": "The ID of the resource"
           },
           "uniqid": {
             "type": "string",
@@ -5267,1827 +5675,107 @@
             "example": "sample29a0e39d",
             "description": "Unique ID of the resource, used as reference across the API."
           },
-          "slug": {
-            "type": "string",
-            "example": "digital-good-to-download",
-            "description": "The slug used to navigate to the product page on a storefront."
-          },
           "shop_id": {
             "type": "number",
             "example": 987,
-            "description": "The shop ID to which this resource belongs."
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "SERIALS",
-              "FILE",
-              "SERVICE",
-              "DYNAMIC",
-              "INFO_CARD",
-              "SUBSCRIPTION"
-            ],
-            "example": "SUBSCRIPTION",
-            "description": "Product type."
-          },
-          "subtype": {
-            "type": "string",
-            "enum": [
-              "SERIALS",
-              "FILE",
-              "SERVICE",
-              "DYNAMIC"
-            ],
-            "example": null,
-            "description": "Product subtype, can be used only with type SUBSCRIPTION."
+            "description": "The unique identifyer for the shop."
           },
           "title": {
             "type": "string",
-            "example": "Digital good to download",
-            "description": "Product title."
-          },
-          "currency": {
-            "$ref": "#/components/schemas/currency"
-          },
-          "pay_what_you_want": {
-            "type": "integer",
-            "example": 1,
-            "description": "Whether or not pay-what-you-want pricing is enabled."
-          },
-          "price": {
-            "type": "number",
-            "format": "double",
-            "example": 5.00,
-            "description": "Product price."
-          },
-          "price_display": {
-            "type": "number",
-            "format": "double",
-            "example": 5.00,
-            "description": "Product price in currency."
-          },
-          "price_discount": {
-            "type": "number",
-            "format": "double",
-            "example": 1.00,
-            "description": "The discount price on the purchased goods."
-          },
-          "affiliate_revenue_percent": {
-            "type": "number",
-            "example": 15,
-            "description": "The percentage of revenue to give to affiliates. -1 for disabled, 0 for default (10%), other number for a custom percent."
-          },
-          "price_variants": {
-            "type": "object",
-            "example": null,
-            "description": "Variants in pricing for the product."
-          },
-          "description": {
-            "type": "string",
-            "example": "Product description",
-            "description": "Product description."
-          },
-          "licensing_enabled": {
-            "type": "integer",
-            "enum": [0,1], 
-            "example": 1,
-            "description": "Whether product licenses are generated on successful payments"
-          },
-          "license_period": {
-            "type": "integer",
-            "example": 7,
-            "description": "Amount in days that licenses will be valid for"
+            "example": "Digital goods to download",
+            "description": "Group title."
           },
           "image_attachment": {
             "$ref": "#/components/schemas/image_attachment"
           },
-          "file_attachment": {
-            "type": "string",
-            "example": null,
-            "description": "Unique id of the file attachment for this product if the product type is FILE."
-          },
-          "youtube_link": {
-            "type": "string",
-            "example": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-            "description": "The url for the YouTube video of the product"
-          },
-          "volume_discounts": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "enum": [
-                    "PERCENTAGE",
-                    "FIXED"
-                  ],
-                  "example": "PERCENTAGE",
-                  "description": "Whether the discount value is a percentage or a fixed amount."
-                },
-                "value": {
-                  "type": "integer",
-                  "example": 5,
-                  "description": "Value of a percentage or fixed discount."
-                },
-                "quantity": {
-                  "type": "integer",
-                  "example": 10,
-                  "description": "How much of this product needs to be purchased in order to be eligible for this volume discount."
-                }
-              }
-            },
-            "description": "Array of volume discounts."
-          },
-          "recurring_interval": {
-            "type": "string",
-            "enum": [
-              "DAY",
-              "WEEK",
-              "MONTH",
-              "YEAR"
-            ],
-            "example": "MONTH",
-            "description": "At which frequency the customer is billed for product type SUBSCRIPTION."
-          },
-          "recurring_interval_count": {
-            "type": "integer",
-            "example": 1,
-            "description": "How many recurring_interval before the customer is billed for product type SUBSCRIPTION."
-          },
-          "trial_period": {
-            "type": "integer",
-            "example": 987,
-            "description": "Defines a trial period before billing the customer for product type SUBSCRIPTION."
-          },
-          "paypal_product_id": {
-            "type": "string",
-            "example": null,
-            "description": "When a product SUBSCRIPTION is created and the gateway PAYPAL chosen, a PayPal product is automatically created on the connected account."
-          },
-          "paypal_plan_id": {
-            "type": "string",
-            "example": null,
-            "description": "When a product SUBSCRIPTION is created and the gateway PAYPAL chosen, a PayPal plan is automatically created on the connected account."
-          },
-          "stripe_price_id": {
-            "type": "string",
-            "example": "price_sample2X7rAeMb7AM5APEU",
-            "description": "When a product SUBSCRIPTION is created and the gateway STRIPE chosen, a Stripe price is automatically created on the connected account."
-          },
-          "discord_integration": {
+          "unlisted": {
             "type": "number",
             "example": 1,
-            "description": "Whether or not the discord integeration is enabled for this product."
-          },
-          "discord_optional": {
-            "type": "number",
-            "example": 1,
-            "description": "Whether or not the discord integration is optional."
-          },
-          "discord_set_role": {
-            "type": "number",
-            "example": 1,
-            "description": "Whether to give users a role when added to the discord server."
-          },
-          "discord_server_id": {
-            "type": "string",
-            "example": "742768752180854827",
-            "description": "The id of the discord server the bot will add users to."
-          },
-          "discord_role_id": {
-            "type": "number",
-            "example": "742772275698335765",
-            "description": "The role to give users when added by the discord integration."
-          },
-          "discord_remove_role": {
-            "type": "number",
-            "example": "0",
-            "description": "Whether to remove a role from the user when added to the discord server."
-          },
-          "quantity_min": {
-            "type": "integer",
-            "minimum": 1,
-            "example": 1,
-            "description": "Minimum quantity purchasable of this product."
-          },
-          "quantity_max": {
-            "type": "integer",
-            "minimum": -1,
-            "example": -1,
-            "description": "Maximum quantity purchasable of this product."
-          },
-          "quantity_warning": {
-            "type": "integer",
-            "example": "0",
-            "description": "At which product quantity should we send a webhook and email warning the merchant."
-          },
-          "gateways": {
-            "$ref": "#/components/schemas/gateways"
-          },
-          "custom_fields": {
-            "$ref": "#/components/schemas/custom_fields_array"
-          },
-          "crypto_confirmations_needed": {
-            "type": "integer",
-            "example": 3,
-            "description": "Minimum number of confirmations for a crypto payment to be accepted."
-          },
-          "max_risk_level": {
-            "type": "integer",
-            "example": 85,
-            "description": "For PAYPAL and STRIPE, maximum risk level to accept payments in order to block fraud attempts."
-          },
-          "block_vpn_proxies": {
-            "type": "boolean",
-            "example": true,
-            "description": "Block VPN and Proxy purchases if the gateway is PAYPAL or STRIPE."
-          },
-          "delivery_text": {
-            "type": "string",
-            "example": "Thank you for purchasing this subscription!",
-            "description": "The text to be delivered to the customer after payment"
-          },
-          "delivery_time": {
-            "type": "integer",
-            "format": "timestamp",
-            "example": 162857125819,
-            "description": "The timestamp for when the invoice was delivered"
-          },
-          "service_text": {
-            "type": "string",
-            "example": "In order to get you services, please contact us at..",
-            "description": "The text to be delivered to the customer after payment for a service"
-          },
-          "stock_delimiter": {
-            "type": "string",
-            "example": ",",
-            "description": "How to delimit the stock if product type is SERIALS, for example with stock_delimiter \",\" and serials value first,second; the stock would have two different serials \"first\" and \"second\"."
-          },
-          "stock": {
-            "type": "integer",
-            "example": -1,
-            "description": "Stock of the current product, can be -1 for unlimited stock."
-          },
-          "dynamic_webhook": {
-            "type": "object",
-            "example": null
-          },
-          "bestseller": {
-            "type": "integer",
-            "example": "0",
-            "description": "DEPRECATED"
+            "description": "Whether or not the product is unlisted."
           },
           "sort_priority": {
-            "type": "integer",
-            "example": 1,
-            "description": "Sort order of this product."
-          },
-          "unlisted": {
-            "type": "boolean",
-            "example": false,
-            "description": "If unlisted is true, the product is not shown in the storefront but can be bought through a direct link."
-          },
-          "on_hold": {
-            "type": "boolean",
-            "example": false,
-            "description": "If on_hold is true, the product cannot be bought but is shown in the storefront."
-          },
-          "terms_of_service": {
-            "type": "string",
-            "example": null,
-            "description": "Text containing the product's terms of service."
-          },
-          "warranty": {
-            "type": "integer",
-            "example": 86400,
-            "description": "Time, in seconds, of how much the warranty for this product lasts."
-          },
-          "warranty_text": {
-            "type": "string",
-            "example": "This warranty covers..",
-            "description": "Clear explanation of what the warranty covers."
-          },
-          "watermark_enabled": {
             "type": "number",
             "example": 1,
-            "description": "Whether sellix should add a watermark to your product image."
-          },
-          "watermark_text": {
-            "type": "string",
-            "example": "Sellix",
-            "description": "The watermark to add to the product image."
-          },
-          "redirect_link": {
-            "type": "string",
-            "example": "https://sellix.io",
-            "description": "The url to redirect a customer to on successful payment"
-          },
-          "label_singular": {
-            "type": "string",
-            "example": null
-          },
-          "label_plural": {
-            "type": "string",
-            "example": null
-          },
-          "private": {
-            "type": "boolean",
-            "example": false,
-            "description": "If private is true, the product is hidden on the storefront and cannot be bought with a direct link."
+            "description": "The priority of the group on the storefront."
           },
           "created_at": {
             "type": "integer",
             "format": "timestamp",
             "example": 162857125819,
-            "description": "Timestamp for the creation of the product."
+            "description": "Timestamp for the creation of the group."
           },
           "updated_at": {
             "type": "integer",
             "format": "timestamp",
             "example": 162857125819,
-            "description": "Date, available if the product has been edited."
+            "description": "Date, available if the group has been edited."
           },
-          "updated_by": {
-            "type": "integer",
-            "format": "timestamp",
-            "example": 987,
-            "description": "User ID, available if the product has been edited."
-          },
-          "marketplace_category_id": {
+          "category_id": {
             "type": "string",
-            "example": "0",
-            "description": "The category ID the product is a part of"
+            "example": "sample29a0e39d",
+            "description": "The category the group is a part of"
           },
-          "telegram_group_id": {
+          "group_id": {
             "type": "string",
-            "example": null,
-            "description": "The Telegram group ID"
+            "example": "sample29a0e39d",
+            "description": "The unique identifyer of the current group"
+          }
+        }
+      },
+      "image_attachment": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
           },
-          "telegram_integration": {
-            "type": "integer",
-            "enum": [0, 1],
-            "example": 1,
-            "description": "Whether or not the Telegram integration is enabled"
-          },
-          "telegram_optional": {
-            "type": "integer",
-            "enum": [0, 1],
-            "example": 1,
-            "description": "Whether or not the Telegram integration is optional"
-          },
-          "image_name": {
+          "uniqid": {
             "type": "string",
-            "example": "SellixImageName.png",
-            "description": "DEPRECATED: The name of the product image with the file type"
-          },
-          "image_storage": {
-            "type": "string",
-            "example": "PRODUCTS",
-            "description": "Where the image is stored in Sellix's self-hosted CDN."
+            "example": "sample2b21744421e9645ed2abef4d303fd16a30fd4bb32f580d7a615ef6e0c7"
           },
           "cloudflare_image_id": {
             "$ref": "#/components/schemas/cloudflare_image_id"
           },
-          "image_attachments": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/image_attachment"
-            }
-          },
-          "feedback": {
-            "type": "object",
-            "properties": {
-              "total": {
-                "type": "integer",
-                "example": 10,
-                "description": "Count of all the feedback."
-              },
-              "positive": {
-                "type": "integer",
-                "example": 8,
-                "description": "Count of positive feedback."
-              },
-              "neutral": {
-                "type": "integer",
-                "example": 1,
-                "description": "Count of neutral feedback."
-              },
-              "negative": {
-                "type": "integer",
-                "example": 1,
-                "description": "Count of negative feedback."
-              },
-              "numbers": {
-                "type": "object",
-                "additionalProperties": {
-                  "type": "integer"
-                },
-                "example": {
-                  "5": 6,
-                  "4": 2,
-                  "3": 1,
-                  "1": 1
-                }
-              },
-              "list": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "score": {
-                      "type": "number",
-                      "example": 5
-                    },
-                    "message": {
-                      "type": "string",
-                      "example": "Nice product!"
-                    },
-                    "reply": {
-                      "type": "string",
-                      "example": "Thank you for the feedback."
-                    },
-                    "created_at": {
-                      "type": "integer",
-                      "format": "timestamp",
-                      "example": 162857125819,
-                      "description": "Timestamp for the creation of the feedback."
-                    },
-                    "updated_at": {
-                      "type": "number",
-                      "example": 162857125819
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "categories": {
-            "type": "array",
-            "items": {
-              "properties": {
-                "title": {
-                  "type": "string",
-                  "example": "Test Category",
-                  "description": "The title of the category"
-                },
-                "uniqid": {
-                  "type": "string",
-                  "example": "sample29a0e39d",
-                  "description": "The unique id of the category"
-                }
-              }
-            }
-          },
-          "payment_gateways_fees": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "integer",
-                  "example": 987
-                },
-                "shop_id": {
-                  "type": "integer",
-                  "example": 987,
-                  "description": "The shop ID to which this resource belongs."
-                },
-                "gateway": {
-                  "type": "string",
-                  "enum": [
-                    "PAYPAL",
-                    "STRIPE",
-                    "SKRILL",
-                    "PERFECT_MONEY",
-                    "CASH_APP",
-                    "BINANCE",
-                    "BITCOIN",
-                    "LITECOIN",
-                    "ETHEREUM",
-                    "BITCOIN_CASH",
-                    "NANO",
-                    "MONERO",
-                    "SOLANA",
-                    "RIPPLE",
-                    "BINANCE_COIN",
-                    "USDC:ERC20",
-                    "USDC:BEP20",
-                    "USDC:MATIC",
-                    "USDC:SOL",
-                    "USDT:ERC20",
-                    "USDT:BEP20",
-                    "USDT:MATIC",
-                    "USDT:SOL",
-                    "USDT:TRC20",
-                    "TRON",
-                    "BITCOIN_LN",
-                    "CONCORDIUM",
-                    "POLYGON",
-                    "PEPE:ERC20",
-                    "DAI:ERC20",
-                    "DAI:BEP20",
-                    "DAI:MATIC",
-                    "WETH:BEP20",
-                    "WETH:MATIC",
-                    "APE:ERC20",
-                    "APE:MATIC",
-                    "SHIB:ERC20",
-                    "SHIB:BEP20",
-                    "SHIB:MATIC",
-                    "USDC_NATIVE:MATIC",
-                    "DOGECOIN",
-                    "PYTH:SOL",
-                    "BONK:SOL",
-                    "JUP:SOL",
-                    "JITO:SOL",
-                    "WEN:SOL",
-                    "RENDER:SOL",
-                    "MOBILE:SOL",
-                    "HNT:SOL"
-                  ],
-                  "example": "STRIPE"
-                },
-                "percent_amount": {
-                  "type": "integer",
-                  "example": -5
-                },
-                "fixed_amount": {
-                  "type": "integer",
-                  "example": "0"
-                },
-                "fixed_currency": {
-                  "$ref": "#/components/schemas/currency"
-                },
-                "active_type": {
-                  "type": "string",
-                  "enum": ["PERCENT", "FIXED"],
-                  "example": "null",
-                  "description": "DEPRECATED"
-                },
-                "updated_at": {
-                  "type": "string",
-                  "example": "1970-01-01 00:00:00"
-                },
-                "created_at": {
-                  "type": "string",
-                  "format": "date-time",
-                  "example": "1975-02-28 00:00:00",
-                  "description": "Datetime for the creation of the resource"
-                }
-              }
-            }
-          }
-        }
-      },
-      "customer": {
-        "type": "object",
-        "properties": {
-          "id": {
+          "storage": {
             "type": "string",
-            "example": "cst_sample37atm91892",
-            "description": "Customer ID"
-          },
-          "shop_id": {
-            "type": "number",
-            "example": 987,
-            "description": "The shop ID to which this customer belongs."
-          },
-          "email": {
-            "type": "string",
-            "example": "sample@gmail.com",
-            "description": "Customer email"
-          },
-          "name": {
-            "type": "string",
-            "example": "James",
-            "description": "Customer name"
-          },
-          "surname": {
-            "type": "string",
-            "example": "Smith",
-            "description": "Customer surname"
-          },
-          "phone": {
-            "type": "string",
-            "example": 3287261000,
-            "description": "Customer phone"
-          },
-          "phone_country_code": {
-            "type": "string",
-            "example": "IT",
-            "description": "Customer phone country code"
-          },
-          "country_code": {
-            "type": "string",
-            "example": "IT",
-            "description": "Customer country code"
-          },
-          "street_address": {
-            "type": "string",
-            "example": "St. Rome 404",
-            "description": "Customer street address"
-          },
-          "additional_address_info": {
-            "type": "string",
-            "example": null,
-            "description": "Customer street address additional info"
-          },
-          "city": {
-            "type": "string",
-            "example": "Rome",
-            "description": "Customer city"
-          },
-          "postal_code": {
-            "type": "string",
-            "example": 987,
-            "description": "Customer postal code"
-          },
-          "state": {
-            "type": "string",
-            "example": "Italy",
-            "description": "Customer state"
-          },
-          "affiliate_revenue": {
-            "type": "string",
-            "example": "0.00",
-            "description": "Revenue customer has recieved from the affiliate program"
-          },
-          "affiliate_revenue_currency": {
-            "type": "string",
-            "example": "EUR",
-            "description": "The currency the customer gets reimbursed in for the affiliate program"
-          },
-          "created_at": {
-            "type": "integer",
-            "format": "timestamp",
-            "example": 162857125819,
-            "description": "Timestamp for the creation of the customer."
-          },
-          "subscriptions": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/subscriptionListing"
-            }
-          },
-          "invoices": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/miniInvoice"
-            }
-          }
-        }
-      },
-      "subscription": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "ID of the subscription.",
-            "example": "rec_sample-3afde4b6e1-82833e"
-          },
-          "shop_id": {
-            "type": "integer",
-            "example": 124,
-            "description": "The shop ID to which this subscription belongs."
-          },
-          "product_id": {
-            "type": "string",
-            "description": "ID of the product subscription.",
-            "example": "samplede6277597"
-          },
-          "status": {
-            "type": "string",
-            "description": "Subscription status.",
-            "enum": [
-              "PENDING",
-              "CANCELED",
-              "TRIALING",
-              "ACTIVE"
-            ],
-            "example": "CANCELED"
-          },
-          "gateway": {
-            "type": "string",
-            "enum": [
-              "PAYPAL",
-              "STRIPE",
-              "SKRILL",
-              "PERFECT_MONEY",
-              "CASH_APP",
-              "BINANCE",
-              "BITCOIN",
-              "LITECOIN",
-              "ETHEREUM",
-              "BITCOIN_CASH",
-              "NANO",
-              "MONERO",
-              "SOLANA",
-              "RIPPLE",
-              "BINANCE_COIN",
-              "USDC:ERC20",
-              "USDC:BEP20",
-              "USDC:MATIC",
-              "USDC:SOL",
-              "USDT:ERC20",
-              "USDT:BEP20",
-              "USDT:MATIC",
-              "USDT:SOL",
-              "USDT:TRC20",
-              "TRON",
-              "BITCOIN_LN",
-              "CONCORDIUM",
-              "POLYGON",
-              "PEPE:ERC20",
-              "DAI:ERC20",
-              "DAI:BEP20",
-              "DAI:MATIC",
-              "WETH:BEP20",
-              "WETH:MATIC",
-              "APE:ERC20",
-              "APE:MATIC",
-              "SHIB:ERC20",
-              "SHIB:BEP20",
-              "SHIB:MATIC",
-              "USDC_NATIVE:MATIC",
-              "DOGECOIN",
-              "PYTH:SOL",
-              "BONK:SOL",
-              "JUP:SOL",
-              "JITO:SOL",
-              "WEN:SOL",
-              "RENDER:SOL",
-              "MOBILE:SOL",
-              "HNT:SOL"
-            ],
-            "example": "STRIPE",
-            "description": "Gateway chosen for this subscription. A new invoice monthly will be created using this gayeway."
-          },
-          "custom_fields": {
-            "$ref": "#/components/schemas/custom_fields_object"
-          },
-          "customer_id": {
-            "type": "string",
-            "description": "ID of the store's customer.",
-            "example": "cst_sample6addc898a645"
-          },
-          "stripe_customer_id": {
-            "type": "string",
-            "description": "ID of the customer created on STRIPE.",
-            "example": "cus_samplegIE0YKwapE6"
-          },
-          "stripe_account": {
-            "type": "string",
-            "description": "ID of the Stripe connected account.",
-            "example": "acct_sampleuMKb2X7rAeMb"
-          },
-          "stripe_subscription_id": {
-            "type": "string",
-            "description": "ID of the Stripe subscription.",
-            "example": "sub_samplexpKb2X7rAeMbKdJc78AP"
-          },
-          "coupon_id": {
-            "type": "string",
-            "description": "If a coupon has been applied, its ID.",
-            "example": null
-          },
-          "current_period_end": {
-            "type": "integer",
-            "format": "timestamp",
-            "description": "When the current billing period will end.",
-            "example": 1641313649
-          },
-          "upcoming_email_1_week_sent": {
-            "type": "boolean",
-            "description": "Whether or not the email for an upcoming renewal has been sent.",
-            "example": false
-          },
-          "trial_period_ending_email_sent": {
-            "type": "boolean",
-            "description": "Whether or not the email for the trial period expiring has been sent.",
-            "example": false
-          },
-          "renewal_invoice_created": {
-            "type": "boolean",
-            "description": "If true, the renewal invoice has already been created.",
-            "example": false
-          },
-          "created_at": {
-            "type": "integer",
-            "format": "timestamp",
-            "example": 162857125819,
-            "description": "Timestamp for the creation of the subscription."
-          },
-          "updated_at": {
-            "type": "integer",
-            "format": "timestamp",
-            "description": "When this subscription was last updated.",
-            "example": 1641315120
-          },
-          "canceled_at": {
-            "type": "integer",
-            "format": "timestamp",
-            "description": "When this subscription was canceled.",
-            "example": null
-          },
-          "product_title": {
-            "type": "string",
-            "description": "Digital Software",
-            "example": "The title of the product for this subscription."
-          },
-          "customer_name": {
-            "type": "string",
-            "description": "Customer name.",
-            "example": "James"
-          },
-          "customer_surname": {
-            "type": "string",
-            "description": "Customer surname.",
-            "example": "Smith"
-          },
-          "customer_phone": {
-            "type": "string",
-            "description": "Customer phone.",
-            "example": null
-          },
-          "customer_phone_country_code": {
-            "type": "string",
-            "description": "Customer phone country code.",
-            "example": null
-          },
-          "customer_country_code": {
-            "type": "string",
-            "description": "Customer country code.",
-            "example": null
-          },
-          "customer_street_address": {
-            "type": "string",
-            "description": "Customer street address.",
-            "example": null
-          },
-          "customer_additional_address_info": {
-            "type": "string",
-            "description": "Customer street address additional info.",
-            "example": null
-          },
-          "customer_city": {
-            "type": "string",
-            "description": "Customer city.",
-            "example": null
-          },
-          "customer_postal_code": {
-            "type": "string",
-            "description": "Customer postal code.",
-            "example": null
-          },
-          "customer_state": {
-            "type": "string",
-            "description": "Customer state.",
-            "example": null
-          },
-          "customer_email": {
-            "type": "string",
-            "description": "Customer email.",
-            "example": "sample@gmail.com"
-          },
-          "invoices": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/invoiceListing"
-            }
-          }
-        }
-      },
-      "subscriptionListing": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "ID of the subscription.",
-            "example": "rec_sample-3afde4b6e1-82833e"
-          },
-          "shop_id": {
-            "type": "integer",
-            "example": 124,
-            "description": "The shop ID to which this subscription belongs."
-          },
-          "product_id": {
-            "type": "string",
-            "description": "ID of the product subscription.",
-            "example": "samplede6277597"
-          },
-          "status": {
-            "type": "string",
-            "description": "Subscription status.",
-            "enum": [
-              "PENDING",
-              "CANCELED",
-              "TRIALING",
-              "ACTIVE"
-            ],
-            "example": "CANCELED"
-          },
-          "gateway": {
-            "type": "string",
-            "enum": [
-              "PAYPAL",
-              "STRIPE",
-              "SKRILL",
-              "PERFECT_MONEY",
-              "CASH_APP",
-              "BINANCE",
-              "BITCOIN",
-              "LITECOIN",
-              "ETHEREUM",
-              "BITCOIN_CASH",
-              "NANO",
-              "MONERO",
-              "SOLANA",
-              "RIPPLE",
-              "BINANCE_COIN",
-              "USDC:ERC20",
-              "USDC:BEP20",
-              "USDC:MATIC",
-              "USDC:SOL",
-              "USDT:ERC20",
-              "USDT:BEP20",
-              "USDT:MATIC",
-              "USDT:SOL",
-              "USDT:TRC20",
-              "TRON",
-              "BITCOIN_LN",
-              "CONCORDIUM",
-              "POLYGON",
-              "PEPE:ERC20",
-              "DAI:ERC20",
-              "DAI:BEP20",
-              "DAI:MATIC",
-              "WETH:BEP20",
-              "WETH:MATIC",
-              "APE:ERC20",
-              "APE:MATIC",
-              "SHIB:ERC20",
-              "SHIB:BEP20",
-              "SHIB:MATIC",
-              "USDC_NATIVE:MATIC",
-              "DOGECOIN",
-              "PYTH:SOL",
-              "BONK:SOL",
-              "JUP:SOL",
-              "JITO:SOL",
-              "WEN:SOL",
-              "RENDER:SOL",
-              "MOBILE:SOL",
-              "HNT:SOL"
-            ],
-            "example": "STRIPE",
-            "description": "Gateway chosen for this subscription. A new invoice monthly will be created using this gayeway."
-          },
-          "custom_fields": {
-            "$ref": "#/components/schemas/custom_fields_object"
-          },
-          "customer_id": {
-            "type": "string",
-            "description": "ID of the store's customer.",
-            "example": "cst_sample6addc898a645"
-          },
-          "stripe_customer_id": {
-            "type": "string",
-            "description": "ID of the customer created on STRIPE.",
-            "example": "cus_samplegIE0YKwapE6"
-          },
-          "stripe_account": {
-            "type": "string",
-            "description": "ID of the Stripe connected account.",
-            "example": "acct_sampleuMKb2X7rAeMb"
-          },
-          "stripe_subscription_id": {
-            "type": "string",
-            "description": "ID of the Stripe subscription.",
-            "example": "sub_samplexpKb2X7rAeMbKdJc78AP"
-          },
-          "coupon_id": {
-            "type": "string",
-            "description": "If a coupon has been applied, its ID.",
-            "example": null
-          },
-          "current_period_end": {
-            "type": "integer",
-            "format": "timestamp",
-            "description": "When the current billing period will end.",
-            "example": 1641313649
-          },
-          "upcoming_email_1_week_sent": {
-            "type": "boolean",
-            "description": "Whether or not the email for an upcoming renewal has been sent.",
-            "example": false
-          },
-          "trial_period_ending_email_sent": {
-            "type": "boolean",
-            "description": "Whether or not the email for the trial period expiring has been sent.",
-            "example": false
-          },
-          "renewal_invoice_created": {
-            "type": "boolean",
-            "description": "If true, the renewal invoice has already been created.",
-            "example": false
-          },
-          "created_at": {
-            "type": "integer",
-            "format": "timestamp",
-            "example": 162857125819,
-            "description": "Timestamp for the creation of the subscription."
-          },
-          "updated_at": {
-            "type": "integer",
-            "format": "timestamp",
-            "description": "When this subscription was last updated.",
-            "example": 1641315120
-          },
-          "canceled_at": {
-            "type": "integer",
-            "format": "timestamp",
-            "description": "When this subscription was canceled.",
-            "example": null
-          },
-          "product_title": {
-            "type": "string",
-            "description": "Digital Software",
-            "example": "The title of the product for this subscription."
-          },
-          "customer_name": {
-            "type": "string",
-            "description": "Customer name.",
-            "example": "James"
-          },
-          "customer_surname": {
-            "type": "string",
-            "description": "Customer surname.",
-            "example": "Smith"
-          },
-          "customer_phone": {
-            "type": "string",
-            "description": "Customer phone.",
-            "example": null
-          },
-          "customer_phone_country_code": {
-            "type": "string",
-            "description": "Customer phone country code.",
-            "example": null
-          },
-          "customer_country_code": {
-            "type": "string",
-            "description": "Customer country code.",
-            "example": null
-          },
-          "customer_street_address": {
-            "type": "string",
-            "description": "Customer street address.",
-            "example": null
-          },
-          "customer_additional_address_info": {
-            "type": "string",
-            "description": "Customer street address additional info.",
-            "example": null
-          },
-          "customer_city": {
-            "type": "string",
-            "description": "Customer city.",
-            "example": null
-          },
-          "customer_postal_code": {
-            "type": "string",
-            "description": "Customer postal code.",
-            "example": null
-          },
-          "customer_state": {
-            "type": "string",
-            "description": "Customer state.",
-            "example": null
-          },
-          "customer_email": {
-            "type": "string",
-            "description": "Customer email.",
-            "example": "sample@gmail.com"
-          }
-        }
-      },
-      "miniInvoice": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "example": 987,
-            "description": "ID of the resource."
-          },
-          "uniqid": {
-            "type": "string",
-            "format": "uuid",
-            "example": "sample-3ddfc9dc3d-ab2e36",
-            "description": "Unique ID of the resource, used as reference across the API."
-          },
-          "recurring_billing_id": {
-            "type": "string",
-            "format": "uuid",
-            "example": null,
-            "description": "Unique ID of the recurring bill."
-          },
-          "billing_period_start": {
-            "type": "number",
-            "example": 162857125819,
-            "description": "The timestamp for when the billing for the invoice started"
-          },
-          "billing_period_end": {
-            "type": "number",
-            "example": null,
-            "description": "The timestamp for when the billing for the invoice ended"
+            "enum": ["PRODUCTS"],
+            "example": "PRODUCTS"
           },
           "type": {
             "type": "string",
-            "enum": [
-              "PRODUCT",
-              "SUBSCRIPTION",
-              "PUBLIC_REST_API",
-              "MONTHLY_BILL",
-              "SHOPPING_CART",
-              "PRODUCT_SUBSCRIPTION"
-            ],
-            "example": "PRODUCT",
-            "description": "Invoice type. For subscriptions, the invoice type is PRODUCT_SUBSCRIPTION as SUBSCRIPTION is reserved for Sellix-own plans."
+            "enum": ["IMAGE"],
+            "example": "IMAGE"
           },
-          "subtype": {
+          "name": {
             "type": "string",
-            "enum": [
-              "SERIALS",
-              "FILE",
-              "SERVICE",
-              "DYNAMIC",
-              "INFO_CARD",
-              "SUBSCRIPTION"
-            ],
-            "example": "SERIALS",
-            "description": "Product type."
+            "example": "sample.png"
           },
-          "origin": {
+          "original_name": {
             "type": "string",
-            "enum": [
-              "STOREFRONT",
-              "API",
-              "EMBED"
-            ],
-            "example": "STOREFRONT",
-            "description": "How the invoice was created"
+            "example": "file.png"
+          },
+          "extension": {
+            "type": "string",
+            "enum": ["png", "webp", "jpg", "jpeg", "avif", "gif"],
+            "example": "png"
           },
           "shop_id": {
             "type": "integer",
             "example": 987,
-            "description": "The shop ID to which this invoice belongs."
-          },
-          "platform_id": {
-            "type": "string",
-            "example": null,
-            "description": "The ID of the wallet platform used during checkout"
-          },
-          "customer_id": {
-            "type": "string",
-            "example": "cst_sample86f8ac433f4a084",
-            "description": "ID of the customer."
+            "description": "The shop ID to which this resource belongs."
           },
           "product_id": {
             "type": "string",
-            "format": "uuid",
-            "example": "sample2bde8a50",
-            "description": "Unique ID of the product linked to this invoice, if any."
+            "example": "sample29a0e39d"
           },
-          "product_variants": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/product_variant"
-            }
-          },
-          "affiliate_revenue_customer_id": {
-            "type": "string",
-            "example": "cst_sample86f8ac433f4a084",
-            "description": "ID of the customer who is affiliated to the purchase."
-          },
-          "product_addons": {
-            "$ref": "#/components/schemas/product_addons"
-          },
-          "product_type": {
-            "type": "string",
-            "enum": [
-              "SERIALS",
-              "FILE",
-              "SERVICE",
-              "DYNAMIC",
-              "INFO_CARD",
-              "SUBSCRIPTION"
-            ],
-            "example": "SERIALS",
-            "description": "Product type."
-          },
-          "product_title": {
-            "type": "string",
-            "example": "Digital Good",
-            "description": "Product title."
-          },
-          "subscription_id": {
+          "size": {
             "type": "integer",
-            "example": null,
-            "description": "Field reserved for Sellix-own plans. Unique ID of the subscription purchased."
-          },
-          "subscription_time": {
-            "type": "integer",
-            "example": null,
-            "description": "Field reserved for Sellix-own plans. Time, in seconds, of the subscription purchased."
-          },
-          "gateway": {
-            "type": "string",
-            "enum": [
-              "PAYPAL",
-              "STRIPE",
-              "SKRILL",
-              "PERFECT_MONEY",
-              "CASH_APP",
-              "BINANCE",
-              "BITCOIN",
-              "LITECOIN",
-              "ETHEREUM",
-              "BITCOIN_CASH",
-              "NANO",
-              "MONERO",
-              "SOLANA",
-              "RIPPLE",
-              "BINANCE_COIN",
-              "USDC",
-              "USDT",
-              "TRON",
-              "BITCOIN_LN",
-              "CONCORDIUM",
-              "POLYGON",
-              "PEPE",
-              "DAI",
-              "WETH",
-              "APE",
-              "SHIB",
-              "USDC_NATIVE",
-              "DOGECOIN",
-              "PYTH",
-              "BONK",
-              "JUP",
-              "JITO",
-              "WEN",
-              "RENDER",
-              "MOBILE",
-              "HNT"
-            ],
-            "example": "LITECOIN",
-            "description": "Gateway chosen for this invoice. If null, the customer will be asked for a gateway in the Sellix hosted invoice page."
-          },
-          "blockchain": {
-            "$ref": "#/components/schemas/blockchain"
-          },
-          "gateways_accepted": {
-            "$ref": "#/components/schemas/gateways"
-          },
-          "paypal_apm": {
-            "type": "string",
-            "example": null,
-            "description": "PayPal Alternative Payment Method name, such as iDEAL, used if gateway is PAYPAL."
-          },
-          "stripe_apm": {
-            "type": "string",
-            "enum": [
-              "afterpay_clearpay",
-              "alipay",
-              "bancontact",
-              "au_becs_debit",
-              "boleto",
-              "eps",
-              "fpx",
-              "giropay",
-              "grabpay",
-              "ideal",
-              "klarna",
-              "oxxo",
-              "p24",
-              "sofort",
-              "wechat_pay"
-            ],
-            "example": null,
-            "description": "Stripe Alternative Payment Method name, such as iDEAL, used if gateway is STRIPE."
-          },
-          "quantity": {
-            "type": "integer",
-            "example": 5,
-            "description": "Qauntity of product purchased."
-          },
-          "total": {
-            "type": "number",
-            "format": "double",
-            "example": 4.5,
-            "description": "Invoice total, unit_price*quantity where quantity is applicable."
-          },
-          "total_display": {
-            "type": "number",
-            "format": "double",
-            "example": 2,
-            "description": "Invoice total in the currency chosen."
-          },
-          "tax_percentage": {
-            "type": "number",
-            "example": 2,
-            "description": "The percentage of tax applied on the transaction"
-          },
-          "coupon_id": {
-            "type": "string",
-            "format": "uuid",
-            "example": null,
-            "description": "Unique ID of the coupon, if used, for the discount."
-          },
-          "discount": {
-            "type": "number",
-            "format": "double",
-            "example": 987,
-            "description": "If a coupon or volume_discount is used, the discount value presents the total amount of discount over the total cost of the invoice."
-          },
-          "discount_display": {
-            "type": "number",
-            "format": "double",
-            "example": 987,
-            "description": "If a coupon or volume_discount is used, the displayed discount value presents the total amount of discount over the total cost of the invoice."
-          },
-          "discount_breakdown": {
-            "type": "object",
-            "example": null,
-            "description": "Representation of how discount was applied to invoice"
-          },
-          "bundle_config": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/bundle_config"
-            }
-          },
-          "volume_discount": {
-            "type": "number",
-            "format": "double",
-            "example": 987,
-            "description": "The discount value applied from a volume_discount."
-          },
-          "volume_discount_display": {
-            "type": "number",
-            "format": "double",
-            "example": 987,
-            "description": "The diplayed discount value applied from a volume_discount."
-          },
-          "currency": {
-            "$ref": "#/components/schemas/currency"
-          },
-          "exchange_rate": {
-            "type": "number",
-            "format": "double",
-            "example": 1.12,
-            "description": "Exchange rate between currency chosen and USD."
-          },
-          "crypto_exchange_rate": {
-            "type": "number",
-            "format": "double",
-            "example": 176.38,
-            "description": "Exchange rate between the cryptocurrency chosen (if any) and USD."
-          },
-          "customer_email": {
-            "type": "string",
-            "example": "customer@gmail.com",
-            "description": "Email of the customer."
-          },
-          "discord_customer_token": {
-            "type": "string",
-            "example": null,
-            "description": "The oauth access token provided by discord during checkout"
-          },
-          "discord_customer_refresh_token": {
-            "type": "string",
-            "example": null,
-            "description": "The oauth refresh token provided by discord during checkout"
-          },
-          "discord_customer_token_expires_at": {
-            "type": "number",
-            "example": null,
-            "description": "Timstamp for the expiration of the discord oauth tokens"
-          },"paypal_email_delivery": {
-            "type": "boolean",
-            "example": false,
-            "description": "If true and gateway is PAYPAL, the product will be shipped to the PayPal email on record instead of the customer email."
-          },
-          "paypal_email": {
-            "type": "string",
-            "example": null,
-            "description": "Merchant PayPal email."
-          },
-          "paypal_order_id": {
-            "type": "string",
-            "example": null,
-            "description": "This field contains the PayPal order ID."
-          },
-          "paypal_authorization_id": {
-            "type": "string",
-            "example": null,
-            "description": "This field contains the PayPal authorization ID."
-          },
-          "paypal_capture_id": {
-            "type": "string",
-            "example": null,
-            "description": "This field contains the PayPal capture ID."
-          },
-          "paypal_payer_email": {
-            "type": "string",
-            "example": null,
-            "description": "This field is updated after the invoice is completed with the PayPal's email used for the purchase."
-          },
-          "paypal_fee": {
-            "type": "string",
-            "example": 987,
-            "description": "This field is updated after the invoice is completed with the fee taken by PayPal over the invoice total."
-          },
-          "paypal_fee_currency": {
-            "$ref": "#/components/schemas/currency"  
-          },
-          "paypal_api_credentials": {
-            "type": "string",
-            "example": "10/01/2021",
-            "description": "This field contains the API version of PayPal that is used."
-          },
-          "paypal_subscription_id": {
-            "type": "integer",
-            "example": null,
-            "description": "ID of the paypal subscription."
-          },
-          "paypal_subscription_link": {
-            "type": "integer",
-            "example": null,
-            "description": "Link for the merchant to purchase the subscription from."
-          },
-          "lex_order_id": {
-            "type": "string",
-            "example": "null",
-            "description": "DEPRECATED"
-          },
-          "lex_payment_method": {
-            "type": "string",
-            "example": "null",
-            "description": "DEPRECATED"
-          },
-          "lex_secret": {
-            "type": "string",
-            "example": "null",
-            "description": "DEPRECATED"
-          },
-          "virtual_payments_id": {
-            "type": "string",
-            "example": "null",
-            "description": "DEPRECATED"
-          },
-          "paydash_paymentID": {
-            "type": "string",
-            "example": "null",
-            "description": "DEPRECATED"
-          },
-          "paydash_apiKey": {
-            "type": "string",
-            "example": "null",
-            "description": "DEPRECATED"
-          },
-          "skrill_email": {
-            "type": "string",
-            "example": null,
-            "description": "Merchant Skrill email."
-          },
-          "skrill_sid": {
-            "type": "string",
-            "example": null,
-            "description": "Skrill unique ID linked to the invoice."
-          },
-          "skrill_link": {
-            "type": "string",
-            "example": null,
-            "description": "Skrill link to redirect the customer to."
-          },
-          "stripe_id": {
-            "type": "string",
-            "example": null,
-            "description": "Client ID used to create the STRIPE paymentIntent."
-          },
-          "stripe_client_secret": {
-            "type": "string",
-            "example": null,
-            "description": "Client secret used to create the STRIPE paymentIntent."
-          },
-          "stripe_price_id": {
-            "type": "string",
-            "example": null,
-            "description": "If the invoice type is PRODUCT_SUBSCRIPTION or SUBSCRIPTION, refers to the STRIPE price ID."
-          },
-          "stripe_customer_id": {
-            "type": "string",
-            "example": null,
-            "description": "The ID of the stripe customer the invoice is for"
-          },
-          "stripe_subscription_id": {
-            "type": "string",
-            "example": null,
-            "description": "If the invoice type is SUBSCRIPTION, refers to the STRIPE subscription ID."
-          },
-          "stripe_invoice_id": {
-            "type": "string",
-            "example": null,
-            "description": "If the invoice type not is SUBSCRIPTION, refers to the STRIPE invoice ID."
-          },
-          "perfectmoney_id": {
-            "type": "string",
-            "format": "uuid",
-            "example": null,
-            "description": "PerfectMoney payment ID linked to the invoice."
-          },
-          "binance_invoice_id": {
-            "type": "string",
-            "example": null,
-            "description": "ID for binance invoice"
-          },
-          "binance_qrcode": {
-            "type": "string",
-            "example": null,
-            "description": "Full Binance QRCODE string"
-          },
-          "binance_checkout_url": {
-            "type": "string",
-            "example": null,
-            "description": "Checkout URL for Binance invoice"
-          },
-          "binance_payout": {
-            "type": "integer",
-            "enum": [0, 1],
-            "example": "0",
-            "description": "Whether or not the binance invoice was payed out"
-          },
-          "cashapp_qrcode": {
-            "type": "string",
-            "example": null,
-            "description": "Full CashApp QRCODE string."
-          },
-          "cashapp_note": {
-            "type": "string",
-            "format": "uuid",
-            "example": null,
-            "description": "Unique note for the customer to leave in the CashApp payment."
-          },
-          "cashapp_cashtag": {
-            "type": "string",
-            "example": null,
-            "description": "CashApp cashtag used to create the QRCODE."
-          },
-          "crypto_address": {
-            "type": "string",
-            "example": "3RUx8gs74R5KdXrs8wU6Z2xQkS8jmGVCnTVTRpwSoE3B",
-            "description": "Cryptocurrency address linked to this invoice."
-          },
-          "crypto_amount": {
-            "type": "number",
-            "format": "double",
-            "example": 0.014174,
-            "description": "Cryptocurrency amount converted based on crypto_exchange_rate."
-          },
-          "crypto_received": {
-            "type": "number",
-            "format": "double",
-            "example": 0.014174,
-            "description": "Cryptocurrency amount received, paid by the customer."
-          },
-          "crypto_fee_paid": {
-            "type": "number",
-            "example": 1,
-            "description": "The amount of money already sent for the crypto transaction's fee"
-          },
-          "crypto_fee_owed": {
-            "type": "number",
-            "example": 1,
-            "description": "The amount remaining to be paid for the crypto transaction's fee"
-          },
-          "crypto_uri": {
-            "type": "string",
-            "example": "solana:3RUx8gs74R5KdXrs8wU6Z2xQkS8jmGVCnTVTRpwSoE3B?amount=0.014174",
-            "description": "URI used to create the QRCODE."
-          },
-          "bitcoin_ln_r_hash": {
-            "type": "string",
-            "example": null,
-            "description": "The bitcoin lightning r hash if applicable"
-          },
-          "crypto_confirmations_needed": {
-            "type": "integer",
-            "example": 1,
-            "description": "Crypto confirmations needed to process the invoice."
-          },
-          "crypto_wallet_version": {
-            "type": "string",
-            "example": "07-05-2023",
-            "description": "The version of the Sellix Crypto Wallet being used"
-          },
-          "crypto_payout": {
-            "type": "boolean",
-            "example": true,
-            "description": "If true, an instant payout for this invoice's cryptocurrency address has been sent."
-          },
-          "crypto_scheduled_payout": {
-            "type": "boolean",
-            "example": false,
-            "description": "If true, a scheduled payout for this invoice's cryptocurrency address has been sent."
-          },
-          "crypto_payout_type": {
-            "type": "string",
-            "enum": ["NOT_DEFINED"],
-            "example": "NOT_DEFINED",
-            "description": "The payout type for the crypto"
-          },
-          "fee_billed": {
-            "type": "boolean",
-            "example": true,
-            "description": "If true, the Sellix fee_percentage has already been collected."
-          },
-          "bill_info": {
-            "type": "object",
-            "example": null,
-            "description": "If invoice type is MONTHLY_BILL, contains a breakdown of the fees that need to be collected."
-          },
-          "country": {
-            "type": "string",
-            "example": "IT",
-            "description": "Customer country."
-          },
-          "location": {
-            "type": "string",
-            "example": "Bologna, Emilia-Romagna (Europe/Rome)",
-            "description": "Customer location."
-          },
-          "ip": {
-            "type": "string",
-            "example": "255.11.12.255",
-            "description": "Customer IP."
-          },
-          "is_vpn_or_proxy": {
-            "type": "boolean",
-            "example": false,
-            "description": "If true, a VPN or Proxy has been detected."
-          },
-          "user_agent": {
-            "type": "string",
-            "example": "PostmanRuntime/7.26.8",
-            "description": "Customer User Agent."
-          },
-          "custom_fields": {
-            "$ref": "#/components/schemas/custom_fields_object"
-          },
-          "developer_invoice": {
-            "type": "boolean",
-            "example": false,
-            "description": "If true, this invoice has been created through the Developers API."
-          },
-          "developer_title": {
-            "type": "string",
-            "example": null,
-            "description": "If a product_id is not passed through the Developers API, a title must be specified."
-          },
-          "developer_webhook": {
-            "type": "string",
-            "example": null,
-            "description": "Additional webhook URL to which updates regarding this invoice will be sent."
-          },
-          "developer_return_url": {
-            "type": "string",
-            "example": null,
-            "description": "If present, the customer will be redirected to this URL after the invoice has been paid."
-          },
-          "payout_configuration": {
-            "type": "string",
-            "example": "null",
-            "description": "DEPRECATED. Value is actually a stringified null"
-          },
-          "fee_percentage": {
-            "type": "integer",
-            "example": 5,
-            "description": "What cut does Sellix take out of the total. To learn more about Sellix fees please refer to https://sellix.io/fees."
-          },
-          "fee_breakdown": {
-            "$ref": "#/components/schemas/fee_breakdown"
-          },
-          "to_process": {
-            "type": "number",
-            "example": "0",
-            "description": "Amount of money left to process"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "PENDING",
-              "COMPLETED",
-              "VOIDED",
-              "WAITING_FOR_CONFIRMATIONS",
-              "PARTIAL",
-              "CUSTOMER_DISPUTE_ONGOING",
-              "REVERSED",
-              "REFUNDED",
-              "WAITING_SHOP_ACTION",
-              "PROCESSING"
-            ],
-            "example": "COMPLETED",
-            "description": "Status of the invoice."
-          },
-          "status_details": {
-            "type": "string",
-            "enum": [
-              "CART_PARTIAL_OUT_OF_STOCK"
-            ],
-            "example": null,
-            "description": "If CART_PARTIAL_OUT_OF_STOCK, the invoice has been completed but some products in the cart were out of stock."
-          },
-          "void_details": {
-            "type": "string",
-            "enum": [
-              "PRODUCT_SOLD_OUT",
-              "CART_PRODUCTS_SOLD_OUT"
-            ],
-            "example": null,
-            "description": "If the invoice is VOIDED and the product (or all the products in the cart) were out of stock, this additional status is set."
-          },
-          "environment": {
-            "type": "string",
-            "enum": [
-              "PRODUCTION"
-            ],
-            "example": "PRODUCTION",
-            "description": "The environment the invoice was made under"
-          },"day_value": {
-            "type": "integer",
-            "example": 28,
-            "description": "Day value, number."
-          },
-          "day": {
-            "type": "string",
-            "example": "Fri",
-            "description": "First three letters of the day name."
-          },
-          "month": {
-            "type": "string",
-            "example": "Feb",
-            "description": "First three letters of the month name."
-          },
-          "year": {
-            "type": "integer",
-            "example": "1975",
-            "description": ": Year number."
+            "example": 987
           },
           "created_at": {
             "type": "integer",
             "format": "timestamp",
             "example": 162857125819,
-            "description": "Timestamp for the creation of the invoice."
-          },
-          "gateway_updated_at": {
-            "type": "integer",
-            "format": "timestamp",
-            "example": null,
-            "description": "Timestamp, available of the last time the gateway has been updated."
-          },
-          "updated_at": {
-            "type": "integer",
-            "format": "timestamp",
-            "example": 162857125819,
-            "description": "Date, available if the blacklist has been edited."
-          },
-          "updated_by": {
-            "type": "integer",
-            "example": 987,
-            "description": "User ID, available if the blacklist has been edited."
-          },
-          "is_marketplace": {
-            "type": "integer",
-            "enum": [0, 1],
-            "example": "0",
-            "description": "Whether or not the invoice was created from a marketplace"
-          },
-          "name": {
-            "type": "string",
-            "example": "Sellix",
-            "description": "Name of the merchant."
-          },
-          "shop_paypal_credit_card": {
-            "type": "boolean",
-            "example": true,
-            "description": "If true, the merchant has enabled purchase with Credit Card through PayPal."
-          },
-          "shop_force_paypal_email_delivery": {
-            "type": "boolean",
-            "example": true,
-            "description": "If true, the merchant has enabled invoice shipment to the PayPal customer email."
+            "description": "Timestamp for the creation of the image."
           }
         }
       },
@@ -7943,6 +6631,208 @@
           }
         }
       },
+      "invoice_status": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "example": 10726392,
+            "description": "Unique ID of the invoice status."
+          },
+          "invoice_id": {
+            "type": "string",
+            "example": "sample-3ddfc9dc3d-ab2e36",
+            "description": "Unique ID of the invoice this status is linked to."
+          },
+          "status": {
+            "enum": [
+              "PENDING",
+              "COMPLETED",
+              "VOIDED",
+              "WAITING_FOR_CONFIRMATIONS",
+              "PARTIAL",
+              "CUSTOMER_DISPUTE_ONGOING",
+              "REVERSED",
+              "REFUNDED",
+              "WAITING_SHOP_ACTION",
+              "PROCESSING"
+            ],
+            "example": "COMPLETED",
+            "description": "Status of the invoice."
+          },
+          "details": {
+            "type": "string",
+            "example": "The invoice has been flagged as completed and the product has been shipped.",
+            "description": "Additional details on the status change."
+          },
+          "created_at": {
+            "type": "integer",
+            "format": "timestamp",
+            "example": 162857125819,
+            "description": "Timestamp for the status change date."
+          }
+        }
+      },
+      "ip_info": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": true,
+            "description": "IP info retrieved successfully."
+          },
+          "message": {
+            "type": "string",
+            "example": "Success",
+            "description": "Any other details linked to this IP."
+          },
+          "fraud_score": {
+            "type": "integer",
+            "maximum": 100,
+            "minimum": 987,
+            "example": 25,
+            "description": "IP Fraud Score details."
+          },
+          "country_code": {
+            "type": "string",
+            "example": "IT",
+            "description": "IP country code."
+          },
+          "region": {
+            "type": "string",
+            "example": "Emilia Romagna",
+            "description": "IP region."
+          },
+          "city": {
+            "type": "string",
+            "example": "Bologna",
+            "description": "IP city."
+          },
+          "ISP": {
+            "type": "string",
+            "example": "Telecom TIM",
+            "description": "IP ISP"
+          },
+          "ASN": {
+            "type": "integer",
+            "example": 308172,
+            "description": "ISP ASN"
+          },
+          "operating_system": {
+            "type": "string",
+            "example": "Mac 10.16",
+            "description": "Customer device operating system."
+          },
+          "browser": {
+            "type": "string",
+            "example": "Chrome 96.0",
+            "description": "Customer device browser."
+          },
+          "organization": {
+            "type": "string",
+            "example": "Telecom TIM",
+            "description": "IP organization."
+          },
+          "is_crawler": {
+            "type": "boolean",
+            "example": false,
+            "description": "If true, the IP has been recently detected as a crawler."
+          },
+          "timezone": {
+            "type": "string",
+            "example": "Europe/Rome",
+            "description": "Customer timezone."
+          },
+          "mobile": {
+            "type": "boolean",
+            "example": false,
+            "description": "If true, the customer used a mobile device."
+          },
+          "host": {
+            "type": "string",
+            "example": "cust.vodafonedsl.it",
+            "description": "ISP host."
+          },
+          "proxy": {
+            "type": "boolean",
+            "example": false,
+            "description": "If true, the IP has been recently detected using a proxy."
+          },
+          "vpn": {
+            "type": "boolean",
+            "example": false,
+            "description": "If true, the IP has been recently detected using a VPN."
+          },
+          "tor": {
+            "type": "boolean",
+            "example": false,
+            "description": "If true, the IP has been recently detected using TOR."
+          },
+          "active_vpn": {
+            "type": "boolean",
+            "example": false,
+            "description": "If true, the IP has an active VPN connection."
+          },
+          "active_tor": {
+            "type": "boolean",
+            "example": false,
+            "description": "If true, the IP has an active TOR connection."
+          },
+          "device_brand": {
+            "type": "string",
+            "example": "Apple",
+            "description": "Customer device brand."
+          },
+          "device_model": {
+            "type": "string",
+            "example": "N/A",
+            "description": "Customer device model."
+          },
+          "recent_abuse": {
+            "type": "boolean",
+            "example": false,
+            "description": "If true, the IP has been recently detected in an online abuse."
+          },
+          "bot_status": {
+            "type": "boolean",
+            "example": false,
+            "description": "If true, the IP has been recently detected as a BOT."
+          },
+          "connection_type": {
+            "type": "string",
+            "example": "Residential",
+            "description": "Customer connection type."
+          },
+          "abuse_velocity": {
+            "type": "string",
+            "example": "none",
+            "description": "IP abuse velocity."
+          },
+          "zip_code": {
+            "type": "string",
+            "example": "N/A",
+            "description": "If detected, customer ZIP code."
+          },
+          "latitude": {
+            "type": "number",
+            "format": "double",
+            "example": 1,
+            "description": "IP latitude."
+          },
+          "longitude": {
+            "type": "number",
+            "format": "double",
+            "example": 2,
+            "description": "IP longitude."
+          },
+          "request_id": {
+            "type": "string",
+            "example": "sampleN0vmX",
+            "description": "IP request ID used for internal reference."
+          }
+        },
+        "description": "Additional info on the customer IP."
+      },
       "invoiceListing": {
         "type": "object",
         "properties": {
@@ -8396,6 +7286,2543 @@
           }
         }
       },
+      "license": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "example": 987,
+            "description": "ID of the resource"
+          },
+          "uniqid": {
+            "type": "string",
+            "format": "uuid",
+            "example": "546f3ede4f1ad",
+            "description": "Unique ID of the resource, used as reference across the API."
+          },
+          "shop_id": {
+            "type": "integer",
+            "example": 987,
+            "description": "The shop ID to which this license belongs."
+          },
+          "product_id": {
+            "type": "string",
+            "example": "sample29a0e39d",
+            "description": "The product ID to which this license belongs."
+          },
+          "invoice_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "sample-3ddfc9dc3d-ab2e3",
+            "description": "Unique ID of the invoice this license is linked to."
+          },
+          "license_key": {
+            "type": "string",
+            "example": "LICENSE-SAMPLE-00",
+            "description": "License key."
+          },
+          "hardware_id": {
+            "type": "string",
+            "example": "098H52ST479QE053V2",
+            "description": "Hardware ID."
+          },
+          "uses": {
+            "type": "integer",
+            "example": 987,
+            "description": "Number of uses for this license, this value is increased at every license check."
+          },
+          "expires_at": {
+            "type": "string",
+            "format": "date-time",
+            "example": "1970-01-01 00:00:00",
+            "description": "Expiration date of the license."
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "example": "1975-02-28 00:00:00",
+            "description": "Creation date of the license."
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "example": "1970-01-01 00:00:00",
+            "description": "Date, available if the license has been updated."
+          }
+        }
+      },
+      "listedProduct": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "example": 987,
+            "description": "Unique ID of the resource, used as reference across the API."
+          },
+          "uniqid": {
+            "type": "string",
+            "format": "uuid",
+            "example": "sample29a0e39d",
+            "description": "Unique ID of the resource, used as reference across the API."
+          },
+          "slug": {
+            "type": "string",
+            "example": "digital-good-to-download",
+            "description": "The slug used to navigate to the product page on a storefront."
+          },
+          "shop_id": {
+            "type": "number",
+            "example": 987,
+            "description": "The shop ID to which this resource belongs."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "SERIALS",
+              "FILE",
+              "SERVICE",
+              "DYNAMIC",
+              "INFO_CARD",
+              "SUBSCRIPTION"
+            ],
+            "example": "SUBSCRIPTION",
+            "description": "Product type."
+          },
+          "subtype": {
+            "type": "string",
+            "enum": [
+              "SERIALS",
+              "FILE",
+              "SERVICE",
+              "DYNAMIC"
+            ],
+            "example": null,
+            "description": "Product subtype, can be used only with type SUBSCRIPTION."
+          },
+          "title": {
+            "type": "string",
+            "example": "Digital good to download",
+            "description": "Product title."
+          },
+          "currency": {
+            "$ref": "#/components/schemas/currency"
+          },
+          "pay_what_you_want": {
+            "type": "integer",
+            "example": 1,
+            "description": "Whether or not pay-what-you-want pricing is enabled."
+          },
+          "price": {
+            "type": "number",
+            "format": "double",
+            "example": 5.00,
+            "description": "Product price."
+          },
+          "price_display": {
+            "type": "number",
+            "format": "double",
+            "example": 5.00,
+            "description": "Product price in currency."
+          },
+          "price_discount": {
+            "type": "number",
+            "format": "double",
+            "example": 1.00,
+            "description": "The discount price on the purchased goods."
+          },
+          "affiliate_revenue_percent": {
+            "type": "number",
+            "example": 15,
+            "description": "The percentage of revenue to give to affiliates. -1 for disabled, 0 for default (10%), other number for a custom percent."
+          },
+          "price_variants": {
+            "type": "object",
+            "example": null,
+            "description": "Variants in pricing for the product."
+          },
+          "description": {
+            "type": "string",
+            "example": "Product description",
+            "description": "Product description."
+          },
+          "licensing_enabled": {
+            "type": "integer",
+            "enum": [0,1], 
+            "example": 1,
+            "description": "Whether product licenses are generated on successful payments"
+          },
+          "license_period": {
+            "type": "integer",
+            "example": 7,
+            "description": "Amount in days that licenses will be valid for"
+          },
+          "image_attachment": {
+            "$ref": "#/components/schemas/image_attachment"
+          },
+          "file_attachment": {
+            "type": "string",
+            "example": null,
+            "description": "Unique id of the file attachment for this product if the product type is FILE."
+          },
+          "youtube_link": {
+            "type": "string",
+            "example": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            "description": "The url for the YouTube video of the product"
+          },
+          "volume_discounts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "PERCENTAGE",
+                    "FIXED"
+                  ],
+                  "example": "PERCENTAGE",
+                  "description": "Whether the discount value is a percentage or a fixed amount."
+                },
+                "value": {
+                  "type": "integer",
+                  "example": 5,
+                  "description": "Value of a percentage or fixed discount."
+                },
+                "quantity": {
+                  "type": "integer",
+                  "example": 10,
+                  "description": "How much of this product needs to be purchased in order to be eligible for this volume discount."
+                }
+              }
+            },
+            "description": "Array of volume discounts."
+          },
+          "recurring_interval": {
+            "type": "string",
+            "enum": [
+              "DAY",
+              "WEEK",
+              "MONTH",
+              "YEAR"
+            ],
+            "example": "MONTH",
+            "description": "At which frequency the customer is billed for product type SUBSCRIPTION."
+          },
+          "recurring_interval_count": {
+            "type": "integer",
+            "example": 1,
+            "description": "How many recurring_interval before the customer is billed for product type SUBSCRIPTION."
+          },
+          "trial_period": {
+            "type": "integer",
+            "example": 987,
+            "description": "Defines a trial period before billing the customer for product type SUBSCRIPTION."
+          },
+          "paypal_product_id": {
+            "type": "string",
+            "example": null,
+            "description": "When a product SUBSCRIPTION is created and the gateway PAYPAL chosen, a PayPal product is automatically created on the connected account."
+          },
+          "paypal_plan_id": {
+            "type": "string",
+            "example": null,
+            "description": "When a product SUBSCRIPTION is created and the gateway PAYPAL chosen, a PayPal plan is automatically created on the connected account."
+          },
+          "stripe_price_id": {
+            "type": "string",
+            "example": "price_sample2X7rAeMb7AM5APEU",
+            "description": "When a product SUBSCRIPTION is created and the gateway STRIPE chosen, a Stripe price is automatically created on the connected account."
+          },
+          "discord_integration": {
+            "type": "number",
+            "example": 1,
+            "description": "Whether or not the discord integeration is enabled for this product."
+          },
+          "discord_optional": {
+            "type": "number",
+            "example": 1,
+            "description": "Whether or not the discord integration is optional."
+          },
+          "discord_set_role": {
+            "type": "number",
+            "example": 1,
+            "description": "Whether to give users a role when added to the discord server."
+          },
+          "discord_server_id": {
+            "type": "string",
+            "example": "742768752180854827",
+            "description": "The id of the discord server the bot will add users to."
+          },
+          "discord_role_id": {
+            "type": "number",
+            "example": "742772275698335765",
+            "description": "The role to give users when added by the discord integration."
+          },
+          "discord_remove_role": {
+            "type": "number",
+            "example": "0",
+            "description": "Whether to remove a role from the user when added to the discord server."
+          },
+          "quantity_min": {
+            "type": "integer",
+            "minimum": 1,
+            "example": 1,
+            "description": "Minimum quantity purchasable of this product."
+          },
+          "quantity_max": {
+            "type": "integer",
+            "minimum": -1,
+            "example": -1,
+            "description": "Maximum quantity purchasable of this product."
+          },
+          "quantity_warning": {
+            "type": "integer",
+            "example": "0",
+            "description": "At which product quantity should we send a webhook and email warning the merchant."
+          },
+          "gateways": {
+            "$ref": "#/components/schemas/gateways"
+          },
+          "custom_fields": {
+            "$ref": "#/components/schemas/custom_fields_array"
+          },
+          "crypto_confirmations_needed": {
+            "type": "integer",
+            "example": 3,
+            "description": "Minimum number of confirmations for a crypto payment to be accepted."
+          },
+          "max_risk_level": {
+            "type": "integer",
+            "example": 85,
+            "description": "For PAYPAL and STRIPE, maximum risk level to accept payments in order to block fraud attempts."
+          },
+          "block_vpn_proxies": {
+            "type": "boolean",
+            "example": true,
+            "description": "Block VPN and Proxy purchases if the gateway is PAYPAL or STRIPE."
+          },
+          "delivery_text": {
+            "type": "string",
+            "example": "Thank you for purchasing this subscription!",
+            "description": "The text to be delivered to the customer after payment"
+          },
+          "delivery_time": {
+            "type": "integer",
+            "format": "timestamp",
+            "example": 162857125819,
+            "description": "The timestamp for when the invoice was delivered"
+          },
+          "service_text": {
+            "type": "string",
+            "example": "In order to get you services, please contact us at..",
+            "description": "The text to be delivered to the customer after payment for a service"
+          },
+          "stock_delimiter": {
+            "type": "string",
+            "example": ",",
+            "description": "How to delimit the stock if product type is SERIALS, for example with stock_delimiter \",\" and serials value first,second; the stock would have two different serials \"first\" and \"second\"."
+          },
+          "stock": {
+            "type": "integer",
+            "example": -1,
+            "description": "Stock of the current product, can be -1 for unlimited stock."
+          },
+          "dynamic_webhook": {
+            "type": "object",
+            "example": null
+          },
+          "bestseller": {
+            "type": "integer",
+            "example": "0",
+            "description": "DEPRECATED"
+          },
+          "sort_priority": {
+            "type": "integer",
+            "example": 1,
+            "description": "Sort order of this product."
+          },
+          "unlisted": {
+            "type": "boolean",
+            "example": false,
+            "description": "If unlisted is true, the product is not shown in the storefront but can be bought through a direct link."
+          },
+          "on_hold": {
+            "type": "boolean",
+            "example": false,
+            "description": "If on_hold is true, the product cannot be bought but is shown in the storefront."
+          },
+          "terms_of_service": {
+            "type": "string",
+            "example": null,
+            "description": "Text containing the product's terms of service."
+          },
+          "warranty": {
+            "type": "integer",
+            "example": 86400,
+            "description": "Time, in seconds, of how much the warranty for this product lasts."
+          },
+          "warranty_text": {
+            "type": "string",
+            "example": "This warranty covers..",
+            "description": "Clear explanation of what the warranty covers."
+          },
+          "watermark_enabled": {
+            "type": "number",
+            "example": 1,
+            "description": "Whether sellix should add a watermark to your product image."
+          },
+          "watermark_text": {
+            "type": "string",
+            "example": "Sellix",
+            "description": "The watermark to add to the product image."
+          },
+          "redirect_link": {
+            "type": "string",
+            "example": "https://sellix.io",
+            "description": "The url to redirect a customer to on successful payment"
+          },
+          "label_singular": {
+            "type": "string",
+            "example": null
+          },
+          "label_plural": {
+            "type": "string",
+            "example": null
+          },
+          "private": {
+            "type": "boolean",
+            "example": false,
+            "description": "If private is true, the product is hidden on the storefront and cannot be bought with a direct link."
+          },
+          "created_at": {
+            "type": "integer",
+            "format": "timestamp",
+            "example": 162857125819,
+            "description": "Timestamp for the creation of the product."
+          },
+          "updated_at": {
+            "type": "integer",
+            "format": "timestamp",
+            "example": 162857125819,
+            "description": "Date, available if the product has been edited."
+          },
+          "updated_by": {
+            "type": "integer",
+            "format": "timestamp",
+            "example": 987,
+            "description": "User ID, available if the product has been edited."
+          },
+          "marketplace_category_id": {
+            "type": "string",
+            "example": "0",
+            "description": "The category ID the product is a part of"
+          },
+          "telegram_group_id": {
+            "type": "string",
+            "example": null,
+            "description": "The Telegram group ID"
+          },
+          "telegram_integration": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Whether or not the Telegram integration is enabled"
+          },
+          "telegram_optional": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Whether or not the Telegram integration is optional"
+          },
+          "image_name": {
+            "type": "string",
+            "example": "SellixImageName.png",
+            "description": "DEPRECATED: The name of the product image with the file type"
+          },
+          "image_storage": {
+            "type": "string",
+            "example": "PRODUCTS",
+            "description": "Where the image is stored in Sellix's self-hosted CDN."
+          },
+          "cloudflare_image_id": {
+            "$ref": "#/components/schemas/cloudflare_image_id"
+          },
+          "image_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/image_attachment"
+            }
+          },
+          "feedback": {
+            "type": "object",
+            "properties": {
+              "total": {
+                "type": "integer",
+                "example": 10,
+                "description": "Count of all the feedback."
+              },
+              "positive": {
+                "type": "integer",
+                "example": 8,
+                "description": "Count of positive feedback."
+              },
+              "neutral": {
+                "type": "integer",
+                "example": 1,
+                "description": "Count of neutral feedback."
+              },
+              "negative": {
+                "type": "integer",
+                "example": 1,
+                "description": "Count of negative feedback."
+              },
+              "numbers": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "integer"
+                },
+                "example": {
+                  "5": 6,
+                  "4": 2,
+                  "3": 1,
+                  "1": 1
+                }
+              },
+              "list": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "score": {
+                      "type": "number",
+                      "example": 5
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Nice product!"
+                    },
+                    "reply": {
+                      "type": "string",
+                      "example": "Thank you for the feedback."
+                    },
+                    "created_at": {
+                      "type": "integer",
+                      "format": "timestamp",
+                      "example": 162857125819,
+                      "description": "Timestamp for the creation of the feedback."
+                    },
+                    "updated_at": {
+                      "type": "number",
+                      "example": 162857125819
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "categories": {
+            "type": "array",
+            "items": {
+              "properties": {
+                "title": {
+                  "type": "string",
+                  "example": "Test Category",
+                  "description": "The title of the category"
+                },
+                "uniqid": {
+                  "type": "string",
+                  "example": "sample29a0e39d",
+                  "description": "The unique id of the category"
+                }
+              }
+            }
+          },
+          "payment_gateways_fees": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer",
+                  "example": 987
+                },
+                "shop_id": {
+                  "type": "integer",
+                  "example": 987,
+                  "description": "The shop ID to which this resource belongs."
+                },
+                "gateway": {
+                  "type": "string",
+                  "enum": [
+                    "PAYPAL",
+                    "STRIPE",
+                    "SKRILL",
+                    "PERFECT_MONEY",
+                    "CASH_APP",
+                    "BINANCE",
+                    "BITCOIN",
+                    "LITECOIN",
+                    "ETHEREUM",
+                    "BITCOIN_CASH",
+                    "NANO",
+                    "MONERO",
+                    "SOLANA",
+                    "RIPPLE",
+                    "BINANCE_COIN",
+                    "USDC:ERC20",
+                    "USDC:BEP20",
+                    "USDC:MATIC",
+                    "USDC:SOL",
+                    "USDT:ERC20",
+                    "USDT:BEP20",
+                    "USDT:MATIC",
+                    "USDT:SOL",
+                    "USDT:TRC20",
+                    "TRON",
+                    "BITCOIN_LN",
+                    "CONCORDIUM",
+                    "POLYGON",
+                    "PEPE:ERC20",
+                    "DAI:ERC20",
+                    "DAI:BEP20",
+                    "DAI:MATIC",
+                    "WETH:BEP20",
+                    "WETH:MATIC",
+                    "APE:ERC20",
+                    "APE:MATIC",
+                    "SHIB:ERC20",
+                    "SHIB:BEP20",
+                    "SHIB:MATIC",
+                    "USDC_NATIVE:MATIC",
+                    "DOGECOIN",
+                    "PYTH:SOL",
+                    "BONK:SOL",
+                    "JUP:SOL",
+                    "JITO:SOL",
+                    "WEN:SOL",
+                    "RENDER:SOL",
+                    "MOBILE:SOL",
+                    "HNT:SOL"
+                  ],
+                  "example": "STRIPE"
+                },
+                "percent_amount": {
+                  "type": "integer",
+                  "example": -5
+                },
+                "fixed_amount": {
+                  "type": "integer",
+                  "example": "0"
+                },
+                "fixed_currency": {
+                  "$ref": "#/components/schemas/currency"
+                },
+                "active_type": {
+                  "type": "string",
+                  "enum": ["PERCENT", "FIXED"],
+                  "example": "null",
+                  "description": "DEPRECATED"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "example": "1970-01-01 00:00:00"
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "example": "1975-02-28 00:00:00",
+                  "description": "Datetime for the creation of the resource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "miniInvoice": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "example": 987,
+            "description": "ID of the resource."
+          },
+          "uniqid": {
+            "type": "string",
+            "format": "uuid",
+            "example": "sample-3ddfc9dc3d-ab2e36",
+            "description": "Unique ID of the resource, used as reference across the API."
+          },
+          "recurring_billing_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": null,
+            "description": "Unique ID of the recurring bill."
+          },
+          "billing_period_start": {
+            "type": "number",
+            "example": 162857125819,
+            "description": "The timestamp for when the billing for the invoice started"
+          },
+          "billing_period_end": {
+            "type": "number",
+            "example": null,
+            "description": "The timestamp for when the billing for the invoice ended"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "PRODUCT",
+              "SUBSCRIPTION",
+              "PUBLIC_REST_API",
+              "MONTHLY_BILL",
+              "SHOPPING_CART",
+              "PRODUCT_SUBSCRIPTION"
+            ],
+            "example": "PRODUCT",
+            "description": "Invoice type. For subscriptions, the invoice type is PRODUCT_SUBSCRIPTION as SUBSCRIPTION is reserved for Sellix-own plans."
+          },
+          "subtype": {
+            "type": "string",
+            "enum": [
+              "SERIALS",
+              "FILE",
+              "SERVICE",
+              "DYNAMIC",
+              "INFO_CARD",
+              "SUBSCRIPTION"
+            ],
+            "example": "SERIALS",
+            "description": "Product type."
+          },
+          "origin": {
+            "type": "string",
+            "enum": [
+              "STOREFRONT",
+              "API",
+              "EMBED"
+            ],
+            "example": "STOREFRONT",
+            "description": "How the invoice was created"
+          },
+          "shop_id": {
+            "type": "integer",
+            "example": 987,
+            "description": "The shop ID to which this invoice belongs."
+          },
+          "platform_id": {
+            "type": "string",
+            "example": null,
+            "description": "The ID of the wallet platform used during checkout"
+          },
+          "customer_id": {
+            "type": "string",
+            "example": "cst_sample86f8ac433f4a084",
+            "description": "ID of the customer."
+          },
+          "product_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "sample2bde8a50",
+            "description": "Unique ID of the product linked to this invoice, if any."
+          },
+          "product_variants": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/product_variant"
+            }
+          },
+          "affiliate_revenue_customer_id": {
+            "type": "string",
+            "example": "cst_sample86f8ac433f4a084",
+            "description": "ID of the customer who is affiliated to the purchase."
+          },
+          "product_addons": {
+            "$ref": "#/components/schemas/product_addons"
+          },
+          "product_type": {
+            "type": "string",
+            "enum": [
+              "SERIALS",
+              "FILE",
+              "SERVICE",
+              "DYNAMIC",
+              "INFO_CARD",
+              "SUBSCRIPTION"
+            ],
+            "example": "SERIALS",
+            "description": "Product type."
+          },
+          "product_title": {
+            "type": "string",
+            "example": "Digital Good",
+            "description": "Product title."
+          },
+          "subscription_id": {
+            "type": "integer",
+            "example": null,
+            "description": "Field reserved for Sellix-own plans. Unique ID of the subscription purchased."
+          },
+          "subscription_time": {
+            "type": "integer",
+            "example": null,
+            "description": "Field reserved for Sellix-own plans. Time, in seconds, of the subscription purchased."
+          },
+          "gateway": {
+            "type": "string",
+            "enum": [
+              "PAYPAL",
+              "STRIPE",
+              "SKRILL",
+              "PERFECT_MONEY",
+              "CASH_APP",
+              "BINANCE",
+              "BITCOIN",
+              "LITECOIN",
+              "ETHEREUM",
+              "BITCOIN_CASH",
+              "NANO",
+              "MONERO",
+              "SOLANA",
+              "RIPPLE",
+              "BINANCE_COIN",
+              "USDC",
+              "USDT",
+              "TRON",
+              "BITCOIN_LN",
+              "CONCORDIUM",
+              "POLYGON",
+              "PEPE",
+              "DAI",
+              "WETH",
+              "APE",
+              "SHIB",
+              "USDC_NATIVE",
+              "DOGECOIN",
+              "PYTH",
+              "BONK",
+              "JUP",
+              "JITO",
+              "WEN",
+              "RENDER",
+              "MOBILE",
+              "HNT"
+            ],
+            "example": "LITECOIN",
+            "description": "Gateway chosen for this invoice. If null, the customer will be asked for a gateway in the Sellix hosted invoice page."
+          },
+          "blockchain": {
+            "$ref": "#/components/schemas/blockchain"
+          },
+          "gateways_accepted": {
+            "$ref": "#/components/schemas/gateways"
+          },
+          "paypal_apm": {
+            "type": "string",
+            "example": null,
+            "description": "PayPal Alternative Payment Method name, such as iDEAL, used if gateway is PAYPAL."
+          },
+          "stripe_apm": {
+            "type": "string",
+            "enum": [
+              "afterpay_clearpay",
+              "alipay",
+              "bancontact",
+              "au_becs_debit",
+              "boleto",
+              "eps",
+              "fpx",
+              "giropay",
+              "grabpay",
+              "ideal",
+              "klarna",
+              "oxxo",
+              "p24",
+              "sofort",
+              "wechat_pay"
+            ],
+            "example": null,
+            "description": "Stripe Alternative Payment Method name, such as iDEAL, used if gateway is STRIPE."
+          },
+          "quantity": {
+            "type": "integer",
+            "example": 5,
+            "description": "Qauntity of product purchased."
+          },
+          "total": {
+            "type": "number",
+            "format": "double",
+            "example": 4.5,
+            "description": "Invoice total, unit_price*quantity where quantity is applicable."
+          },
+          "total_display": {
+            "type": "number",
+            "format": "double",
+            "example": 2,
+            "description": "Invoice total in the currency chosen."
+          },
+          "tax_percentage": {
+            "type": "number",
+            "example": 2,
+            "description": "The percentage of tax applied on the transaction"
+          },
+          "coupon_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": null,
+            "description": "Unique ID of the coupon, if used, for the discount."
+          },
+          "discount": {
+            "type": "number",
+            "format": "double",
+            "example": 987,
+            "description": "If a coupon or volume_discount is used, the discount value presents the total amount of discount over the total cost of the invoice."
+          },
+          "discount_display": {
+            "type": "number",
+            "format": "double",
+            "example": 987,
+            "description": "If a coupon or volume_discount is used, the displayed discount value presents the total amount of discount over the total cost of the invoice."
+          },
+          "discount_breakdown": {
+            "type": "object",
+            "example": null,
+            "description": "Representation of how discount was applied to invoice"
+          },
+          "bundle_config": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/bundle_config"
+            }
+          },
+          "volume_discount": {
+            "type": "number",
+            "format": "double",
+            "example": 987,
+            "description": "The discount value applied from a volume_discount."
+          },
+          "volume_discount_display": {
+            "type": "number",
+            "format": "double",
+            "example": 987,
+            "description": "The diplayed discount value applied from a volume_discount."
+          },
+          "currency": {
+            "$ref": "#/components/schemas/currency"
+          },
+          "exchange_rate": {
+            "type": "number",
+            "format": "double",
+            "example": 1.12,
+            "description": "Exchange rate between currency chosen and USD."
+          },
+          "crypto_exchange_rate": {
+            "type": "number",
+            "format": "double",
+            "example": 176.38,
+            "description": "Exchange rate between the cryptocurrency chosen (if any) and USD."
+          },
+          "customer_email": {
+            "type": "string",
+            "example": "customer@gmail.com",
+            "description": "Email of the customer."
+          },
+          "discord_customer_token": {
+            "type": "string",
+            "example": null,
+            "description": "The oauth access token provided by discord during checkout"
+          },
+          "discord_customer_refresh_token": {
+            "type": "string",
+            "example": null,
+            "description": "The oauth refresh token provided by discord during checkout"
+          },
+          "discord_customer_token_expires_at": {
+            "type": "number",
+            "example": null,
+            "description": "Timstamp for the expiration of the discord oauth tokens"
+          },"paypal_email_delivery": {
+            "type": "boolean",
+            "example": false,
+            "description": "If true and gateway is PAYPAL, the product will be shipped to the PayPal email on record instead of the customer email."
+          },
+          "paypal_email": {
+            "type": "string",
+            "example": null,
+            "description": "Merchant PayPal email."
+          },
+          "paypal_order_id": {
+            "type": "string",
+            "example": null,
+            "description": "This field contains the PayPal order ID."
+          },
+          "paypal_authorization_id": {
+            "type": "string",
+            "example": null,
+            "description": "This field contains the PayPal authorization ID."
+          },
+          "paypal_capture_id": {
+            "type": "string",
+            "example": null,
+            "description": "This field contains the PayPal capture ID."
+          },
+          "paypal_payer_email": {
+            "type": "string",
+            "example": null,
+            "description": "This field is updated after the invoice is completed with the PayPal's email used for the purchase."
+          },
+          "paypal_fee": {
+            "type": "string",
+            "example": 987,
+            "description": "This field is updated after the invoice is completed with the fee taken by PayPal over the invoice total."
+          },
+          "paypal_fee_currency": {
+            "$ref": "#/components/schemas/currency"  
+          },
+          "paypal_api_credentials": {
+            "type": "string",
+            "example": "10/01/2021",
+            "description": "This field contains the API version of PayPal that is used."
+          },
+          "paypal_subscription_id": {
+            "type": "integer",
+            "example": null,
+            "description": "ID of the paypal subscription."
+          },
+          "paypal_subscription_link": {
+            "type": "integer",
+            "example": null,
+            "description": "Link for the merchant to purchase the subscription from."
+          },
+          "lex_order_id": {
+            "type": "string",
+            "example": "null",
+            "description": "DEPRECATED"
+          },
+          "lex_payment_method": {
+            "type": "string",
+            "example": "null",
+            "description": "DEPRECATED"
+          },
+          "lex_secret": {
+            "type": "string",
+            "example": "null",
+            "description": "DEPRECATED"
+          },
+          "virtual_payments_id": {
+            "type": "string",
+            "example": "null",
+            "description": "DEPRECATED"
+          },
+          "paydash_paymentID": {
+            "type": "string",
+            "example": "null",
+            "description": "DEPRECATED"
+          },
+          "paydash_apiKey": {
+            "type": "string",
+            "example": "null",
+            "description": "DEPRECATED"
+          },
+          "skrill_email": {
+            "type": "string",
+            "example": null,
+            "description": "Merchant Skrill email."
+          },
+          "skrill_sid": {
+            "type": "string",
+            "example": null,
+            "description": "Skrill unique ID linked to the invoice."
+          },
+          "skrill_link": {
+            "type": "string",
+            "example": null,
+            "description": "Skrill link to redirect the customer to."
+          },
+          "stripe_id": {
+            "type": "string",
+            "example": null,
+            "description": "Client ID used to create the STRIPE paymentIntent."
+          },
+          "stripe_client_secret": {
+            "type": "string",
+            "example": null,
+            "description": "Client secret used to create the STRIPE paymentIntent."
+          },
+          "stripe_price_id": {
+            "type": "string",
+            "example": null,
+            "description": "If the invoice type is PRODUCT_SUBSCRIPTION or SUBSCRIPTION, refers to the STRIPE price ID."
+          },
+          "stripe_customer_id": {
+            "type": "string",
+            "example": null,
+            "description": "The ID of the stripe customer the invoice is for"
+          },
+          "stripe_subscription_id": {
+            "type": "string",
+            "example": null,
+            "description": "If the invoice type is SUBSCRIPTION, refers to the STRIPE subscription ID."
+          },
+          "stripe_invoice_id": {
+            "type": "string",
+            "example": null,
+            "description": "If the invoice type not is SUBSCRIPTION, refers to the STRIPE invoice ID."
+          },
+          "perfectmoney_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": null,
+            "description": "PerfectMoney payment ID linked to the invoice."
+          },
+          "binance_invoice_id": {
+            "type": "string",
+            "example": null,
+            "description": "ID for binance invoice"
+          },
+          "binance_qrcode": {
+            "type": "string",
+            "example": null,
+            "description": "Full Binance QRCODE string"
+          },
+          "binance_checkout_url": {
+            "type": "string",
+            "example": null,
+            "description": "Checkout URL for Binance invoice"
+          },
+          "binance_payout": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": "0",
+            "description": "Whether or not the binance invoice was payed out"
+          },
+          "cashapp_qrcode": {
+            "type": "string",
+            "example": null,
+            "description": "Full CashApp QRCODE string."
+          },
+          "cashapp_note": {
+            "type": "string",
+            "format": "uuid",
+            "example": null,
+            "description": "Unique note for the customer to leave in the CashApp payment."
+          },
+          "cashapp_cashtag": {
+            "type": "string",
+            "example": null,
+            "description": "CashApp cashtag used to create the QRCODE."
+          },
+          "crypto_address": {
+            "type": "string",
+            "example": "3RUx8gs74R5KdXrs8wU6Z2xQkS8jmGVCnTVTRpwSoE3B",
+            "description": "Cryptocurrency address linked to this invoice."
+          },
+          "crypto_amount": {
+            "type": "number",
+            "format": "double",
+            "example": 0.014174,
+            "description": "Cryptocurrency amount converted based on crypto_exchange_rate."
+          },
+          "crypto_received": {
+            "type": "number",
+            "format": "double",
+            "example": 0.014174,
+            "description": "Cryptocurrency amount received, paid by the customer."
+          },
+          "crypto_fee_paid": {
+            "type": "number",
+            "example": 1,
+            "description": "The amount of money already sent for the crypto transaction's fee"
+          },
+          "crypto_fee_owed": {
+            "type": "number",
+            "example": 1,
+            "description": "The amount remaining to be paid for the crypto transaction's fee"
+          },
+          "crypto_uri": {
+            "type": "string",
+            "example": "solana:3RUx8gs74R5KdXrs8wU6Z2xQkS8jmGVCnTVTRpwSoE3B?amount=0.014174",
+            "description": "URI used to create the QRCODE."
+          },
+          "bitcoin_ln_r_hash": {
+            "type": "string",
+            "example": null,
+            "description": "The bitcoin lightning r hash if applicable"
+          },
+          "crypto_confirmations_needed": {
+            "type": "integer",
+            "example": 1,
+            "description": "Crypto confirmations needed to process the invoice."
+          },
+          "crypto_wallet_version": {
+            "type": "string",
+            "example": "07-05-2023",
+            "description": "The version of the Sellix Crypto Wallet being used"
+          },
+          "crypto_payout": {
+            "type": "boolean",
+            "example": true,
+            "description": "If true, an instant payout for this invoice's cryptocurrency address has been sent."
+          },
+          "crypto_scheduled_payout": {
+            "type": "boolean",
+            "example": false,
+            "description": "If true, a scheduled payout for this invoice's cryptocurrency address has been sent."
+          },
+          "crypto_payout_type": {
+            "type": "string",
+            "enum": ["NOT_DEFINED"],
+            "example": "NOT_DEFINED",
+            "description": "The payout type for the crypto"
+          },
+          "fee_billed": {
+            "type": "boolean",
+            "example": true,
+            "description": "If true, the Sellix fee_percentage has already been collected."
+          },
+          "bill_info": {
+            "type": "object",
+            "example": null,
+            "description": "If invoice type is MONTHLY_BILL, contains a breakdown of the fees that need to be collected."
+          },
+          "country": {
+            "type": "string",
+            "example": "IT",
+            "description": "Customer country."
+          },
+          "location": {
+            "type": "string",
+            "example": "Bologna, Emilia-Romagna (Europe/Rome)",
+            "description": "Customer location."
+          },
+          "ip": {
+            "type": "string",
+            "example": "255.11.12.255",
+            "description": "Customer IP."
+          },
+          "is_vpn_or_proxy": {
+            "type": "boolean",
+            "example": false,
+            "description": "If true, a VPN or Proxy has been detected."
+          },
+          "user_agent": {
+            "type": "string",
+            "example": "PostmanRuntime/7.26.8",
+            "description": "Customer User Agent."
+          },
+          "custom_fields": {
+            "$ref": "#/components/schemas/custom_fields_object"
+          },
+          "developer_invoice": {
+            "type": "boolean",
+            "example": false,
+            "description": "If true, this invoice has been created through the Developers API."
+          },
+          "developer_title": {
+            "type": "string",
+            "example": null,
+            "description": "If a product_id is not passed through the Developers API, a title must be specified."
+          },
+          "developer_webhook": {
+            "type": "string",
+            "example": null,
+            "description": "Additional webhook URL to which updates regarding this invoice will be sent."
+          },
+          "developer_return_url": {
+            "type": "string",
+            "example": null,
+            "description": "If present, the customer will be redirected to this URL after the invoice has been paid."
+          },
+          "payout_configuration": {
+            "type": "string",
+            "example": "null",
+            "description": "DEPRECATED. Value is actually a stringified null"
+          },
+          "fee_percentage": {
+            "type": "integer",
+            "example": 5,
+            "description": "What cut does Sellix take out of the total. To learn more about Sellix fees please refer to https://sellix.io/fees."
+          },
+          "fee_breakdown": {
+            "$ref": "#/components/schemas/fee_breakdown"
+          },
+          "to_process": {
+            "type": "number",
+            "example": "0",
+            "description": "Amount of money left to process"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "PENDING",
+              "COMPLETED",
+              "VOIDED",
+              "WAITING_FOR_CONFIRMATIONS",
+              "PARTIAL",
+              "CUSTOMER_DISPUTE_ONGOING",
+              "REVERSED",
+              "REFUNDED",
+              "WAITING_SHOP_ACTION",
+              "PROCESSING"
+            ],
+            "example": "COMPLETED",
+            "description": "Status of the invoice."
+          },
+          "status_details": {
+            "type": "string",
+            "enum": [
+              "CART_PARTIAL_OUT_OF_STOCK"
+            ],
+            "example": null,
+            "description": "If CART_PARTIAL_OUT_OF_STOCK, the invoice has been completed but some products in the cart were out of stock."
+          },
+          "void_details": {
+            "type": "string",
+            "enum": [
+              "PRODUCT_SOLD_OUT",
+              "CART_PRODUCTS_SOLD_OUT"
+            ],
+            "example": null,
+            "description": "If the invoice is VOIDED and the product (or all the products in the cart) were out of stock, this additional status is set."
+          },
+          "environment": {
+            "type": "string",
+            "enum": [
+              "PRODUCTION"
+            ],
+            "example": "PRODUCTION",
+            "description": "The environment the invoice was made under"
+          },"day_value": {
+            "type": "integer",
+            "example": 28,
+            "description": "Day value, number."
+          },
+          "day": {
+            "type": "string",
+            "example": "Fri",
+            "description": "First three letters of the day name."
+          },
+          "month": {
+            "type": "string",
+            "example": "Feb",
+            "description": "First three letters of the month name."
+          },
+          "year": {
+            "type": "integer",
+            "example": "1975",
+            "description": ": Year number."
+          },
+          "created_at": {
+            "type": "integer",
+            "format": "timestamp",
+            "example": 162857125819,
+            "description": "Timestamp for the creation of the invoice."
+          },
+          "gateway_updated_at": {
+            "type": "integer",
+            "format": "timestamp",
+            "example": null,
+            "description": "Timestamp, available of the last time the gateway has been updated."
+          },
+          "updated_at": {
+            "type": "integer",
+            "format": "timestamp",
+            "example": 162857125819,
+            "description": "Date, available if the blacklist has been edited."
+          },
+          "updated_by": {
+            "type": "integer",
+            "example": 987,
+            "description": "User ID, available if the blacklist has been edited."
+          },
+          "is_marketplace": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": "0",
+            "description": "Whether or not the invoice was created from a marketplace"
+          },
+          "name": {
+            "type": "string",
+            "example": "Sellix",
+            "description": "Name of the merchant."
+          },
+          "shop_paypal_credit_card": {
+            "type": "boolean",
+            "example": true,
+            "description": "If true, the merchant has enabled purchase with Credit Card through PayPal."
+          },
+          "shop_force_paypal_email_delivery": {
+            "type": "boolean",
+            "example": true,
+            "description": "If true, the merchant has enabled invoice shipment to the PayPal customer email."
+          }
+        }
+      },
+      "payment_response": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "integer",
+            "example": 200
+          },
+          "data": {
+            "type": "object",
+            "required": [
+              "url",
+              "uniqid"
+            ],
+            "properties": {
+              "url": {
+                "type": "string",
+                "description": "Sellix hosted payment page."
+              },
+              "uniqid": {
+                "type": "string",
+                "format": "uuid",
+                "description": "Unique ID of the invoice created for the payment."
+              }
+            },
+            "example": {
+              "url": "https://sellix.io/payment/sample-4caac117ca-abeb80",
+              "uniqid": "sample-4caac117ca-abeb80"
+            }
+          },
+          "error": {
+            "type": "string",
+            "example": null
+          },
+          "message": {
+            "type": "string",
+            "example": "<success-message>"
+          },
+          "env": {
+            "type": "string",
+            "example": "production"
+          },
+          "log": {
+            "type": "object",
+            "example": null
+          }
+        }
+      },
+      "payment_response_white_label": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "integer",
+            "example": 200
+          },
+          "data": {
+            "type": "object",
+            "required": [
+              "invoice"
+            ],
+            "properties": {
+              "invoice": {
+                "$ref": "#/components/schemas/invoice"
+              }
+            },
+            "example": {
+              "invoice": {
+                "uniqid": "sample-4caac117ca-abeb80",
+                "...": null
+              }
+            }
+          },
+          "message": {
+            "type": "string",
+            "example": "<success-message>"
+          },
+          "log": {
+            "type": "object",
+            "example": null
+          },
+          "error": {
+            "type": "string",
+            "example": null
+          },
+          "env": {
+            "type": "string",
+            "example": "production"
+          }
+        }
+      },
+      "paypal_dispute": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "PP-D-sample1379",
+            "description": "Unique ID of the resource, used as reference across the API."
+          },
+          "invoice_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "sample-bd73112377-6c0064",
+            "description": "Unique ID of the invoice linked to this dispute."
+          },
+          "shop_id": {
+            "type": "integer",
+            "example": 987,
+            "description": "The shop ID to which this paypal dispute belongs."
+          },
+          "reason": {
+            "type": "string",
+            "enum": [
+              "MERCHANDISE_OR_SERVICE_NOT_RECEIVED",
+              "INCORRECT_AMOUNT",
+              "MERCHANDISE_OR_SERVICE_NOT_AS_DESCRIBED",
+              "PAYMENT_BY_OTHER_MEANS",
+              "UNAUTHORISED",
+              "CANCELED_RECURRING_BILLING",
+              "CREDIT_NOT_PROCESSED",
+              "PROBLEM_WITH_REMITTANCE",
+              "DUPLICATE_TRANSACTION",
+              "OTHER"
+            ],
+            "example": "MERCHANDISE_OR_SERVICE_NOT_RECEIVED",
+            "description": "The dispute reason is why the customer has opened a dispute against your order."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "OPEN",
+              "UNDER_REVIEW",
+              "WAITING_FOR_BUYER_RESPONSE",
+              "RESOLVED",
+              "WAITING_FOR_SELLER_RESPONSE",
+              "OTHER"
+            ],
+            "example": "WAITING_FOR_BUYER_RESPONSE",
+            "description": "Each dispute is automatically updated when we receive an update from PayPal, the status indicates how it is going."
+          },
+          "outcome": {
+            "type": "string",
+            "enum": [
+              "RESOLVED_BUYER_FAVOUR",
+              "CANCELED_BY_BUYER",
+              "RESOLVED_SELLER_FAVOUR",
+              "ACCEPTED",
+              "RESOLVED_WITH_PAYOUT",
+              "DENIED",
+              "NONE"
+            ],
+            "example": null,
+            "description": "When a dispute it’s solved, its outcome is updated."
+          },
+          "messages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/paypal_dispute_message"
+            },
+            "example": [
+              {
+                "posted_by": "SELLER",
+                "content": "Hello your order is completed",
+                "created_at": 1641033844
+              }
+            ]
+          },
+          "life_cycle_stage": {
+            "type": "string",
+            "enum": [
+              "INQUIRY",
+              "ARBITRATION",
+              "CHARGEBACK",
+              "PRE_ARBITRATION"
+            ],
+            "example": "INQUIRY",
+            "description": "The stage in the dispute lifecycle."
+          },
+          "seller_response_due_date": {
+            "type": "integer",
+            "format": "timestamp",
+            "example": 987,
+            "description": "Within which date the seller needs to respond."
+          },
+          "created_at": {
+            "type": "integer",
+            "format": "timestamp",
+            "example": 162857125819,
+            "description": "Timestamp for the creation of the dispute."
+          },
+          "updated_at": {
+            "type": "integer",
+            "format": "timestamp",
+            "example": 162857125819,
+            "description": "When the dispute was updated."
+          }
+        }
+      },
+      "paypal_dispute_message": {
+        "type": "object",
+        "properties": {
+          "posted_by": {
+            "type": "string",
+            "enum": [
+              "BUYER",
+              "ARBITER",
+              "SELLER"
+            ],
+            "example": "SELLER",
+            "description": "Indicates whether the customer, merchant, or dispute arbiter posted the message."
+          },
+          "content": {
+            "type": "string",
+            "example": "Hello your order is completed",
+            "description": "The content of the dispute message."
+          },
+          "created_at": {
+            "type": "integer",
+            "format": "timestamp",
+            "example": 162857125819,
+            "description": "Timestamp for when the message was sent"
+          }
+        }
+      },
+      "product": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "example": 987,
+            "description": "Unique ID of the resource, used as reference across the API."
+          },
+          "uniqid": {
+            "type": "string",
+            "format": "uuid",
+            "example": "sample29a0e39d",
+            "description": "Unique ID of the resource, used as reference across the API."
+          },
+          "slug": {
+            "type": "string",
+            "example": "digital-good-to-download",
+            "description": "The slug used to navigate to the product page on a storefront."
+          },
+          "shop_id": {
+            "type": "number",
+            "example": 987,
+            "description": "The shop ID to which this resource belongs."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "SERIALS",
+              "FILE",
+              "SERVICE",
+              "DYNAMIC",
+              "INFO_CARD",
+              "SUBSCRIPTION"
+            ],
+            "example": "SUBSCRIPTION",
+            "description": "Product type."
+          },
+          "subtype": {
+            "type": "string",
+            "enum": [
+              "SERIALS",
+              "FILE",
+              "SERVICE",
+              "DYNAMIC"
+            ],
+            "example": null,
+            "description": "Product subtype, can be used only with type SUBSCRIPTION."
+          },
+          "title": {
+            "type": "string",
+            "example": "Digital good to download",
+            "description": "Product title."
+          },
+          "currency": {
+            "$ref": "#/components/schemas/currency"
+          },
+          "pay_what_you_want": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Whether or not pay-what-you-want pricing is enabled."
+          },
+          "price": {
+            "type": "number",
+            "format": "double",
+            "example": 4.00,
+            "description": "Product price."
+          },
+          "price_display": {
+            "type": "number",
+            "format": "double",
+            "example": 5.00,
+            "description": "Product price in currency."
+          },
+          "price_discount": {
+            "type": "number",
+            "format": "double",
+            "example": 1.00,
+            "description": "The discount price on the purchased goods."
+          },
+          "affiliate_revenue_percent": {
+            "type": "number",
+            "example": 15,
+            "description": "The percentage of revenue to give to affiliates. -1 for disabled, 0 for default (10%), other number for a custom percent."
+          },
+          "price_variants": {
+            "type": "object",
+            "example": null,
+            "description": "Variants in pricing for the product."
+          },
+          "description": {
+            "type": "string",
+            "example": "Product description",
+            "description": "Product description."
+          },
+          "licensing_enabled": {
+            "type": "integer", 
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Whether product licenses are generated on successful payments"
+          },
+          "license_period": {
+            "type": "integer",
+            "example": 7,
+            "description": "Amount in days that licenses will be valid for"
+          },
+          "image_attachment": {
+            "$ref": "#/components/schemas/image_attachment"
+          },
+          "file_attachment": {
+            "type": "string",
+            "example": null,
+            "description": "Unique id of the file attachment for this product if the product type is FILE."
+          },
+          "youtube_link": {
+            "type": "string",
+            "example": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            "description": "The url for the YouTube video of the product"
+          },
+          "volume_discounts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "PERCENTAGE",
+                    "FIXED"
+                  ],
+                  "example": "PERCENTAGE",
+                  "description": "Whether the discount value is a percentage or a fixed amount."
+                },
+                "value": {
+                  "type": "integer",
+                  "example": 5,
+                  "description": "Value of a percentage or fixed discount."
+                },
+                "quantity": {
+                  "type": "integer",
+                  "example": 10,
+                  "description": "How much of this product needs to be purchased in order to be eligible for this volume discount."
+                }
+              }
+            },
+            "description": "Array of volume discounts."
+          },
+          "recurring_interval": {
+            "type": "string",
+            "enum": [
+              "DAY",
+              "WEEK",
+              "MONTH",
+              "YEAR"
+            ],
+            "example": "MONTH",
+            "description": "At which frequency the customer is billed for product type SUBSCRIPTION."
+          },
+          "recurring_interval_count": {
+            "type": "integer",
+            "example": 1,
+            "description": "How many recurring_interval before the customer is billed for product type SUBSCRIPTION."
+          },
+          "trial_period": {
+            "type": "integer",
+            "example": "0",
+            "description": "Defines a trial period before billing the customer for product type SUBSCRIPTION."
+          },
+          "paypal_product_id": {
+            "type": "string",
+            "example": null,
+            "description": "When a product SUBSCRIPTION is created and the gateway PAYPAL chosen, a PayPal product is automatically created on the connected account."
+          },
+          "paypal_plan_id": {
+            "type": "string",
+            "example": null,
+            "description": "When a product SUBSCRIPTION is created and the gateway PAYPAL chosen, a PayPal plan is automatically created on the connected account."
+          },
+          "stripe_price_id": {
+            "type": "string",
+            "example": "price_sample2X7rAeMb7AM5APEU",
+            "description": "When a product SUBSCRIPTION is created and the gateway STRIPE chosen, a Stripe price is automatically created on the connected account."
+          },
+          "discord_integration": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Whether or not the discord integeration is enabled for this product."
+          },
+          "discord_optional": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Whether or not the discord integration is optional."
+          },
+          "discord_set_role": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Whether to give users a role when added to the discord server."
+          },
+          "discord_server_id": {
+            "type": "string",
+            "example": "742768752180854827",
+            "description": "The id of the discord server the bot will add users to."
+          },
+          "discord_role_id": {
+            "type": "number",
+            "example": "742772275698335765",
+            "description": "The role to give users when added by the discord integration."
+          },
+          "discord_remove_role": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": "0",
+            "description": "Whether to remove a role from the user when added to the discord server."
+          },
+          "quantity_min": {
+            "type": "integer",
+            "minimum": 1,
+            "example": 1,
+            "description": "Minimum quantity purchasable of this product."
+          },
+          "quantity_max": {
+            "type": "integer",
+            "minimum": -1,
+            "example": -1,
+            "description": "Maximum quantity purchasable of this product."
+          },
+          "quantity_warning": {
+            "type": "integer",
+            "example": "0",
+            "description": "At which product quantity should we send a webhook and email warning the merchant."
+          },
+          "gateways": {
+            "$ref": "#/components/schemas/gateways"
+          },
+          "custom_fields": {
+            "$ref": "#/components/schemas/custom_fields_array"
+          },
+          "crypto_confirmations_needed": {
+            "type": "integer",
+            "example": 3,
+            "description": "Minimum number of confirmations for a crypto payment to be accepted."
+          },
+          "max_risk_level": {
+            "type": "integer",
+            "example": 85,
+            "description": "For PAYPAL and STRIPE, maximum risk level to accept payments in order to block fraud attempts."
+          },
+          "block_vpn_proxies": {
+            "type": "boolean",
+            "example": true,
+            "description": "Block VPN and Proxy purchases if the gateway is PAYPAL or STRIPE."
+          },
+          "delivery_text": {
+            "type": "string",
+            "example": "Thank you for purchasing this subscription!",
+            "description": "The text to be delivered to the customer after payment"
+          },
+          "delivery_time": {
+            "type": "integer",
+            "example": 162857125819,
+            "description": "The timestamp for when the invoice was delivered"
+          },
+          "service_text": {
+            "type": "string",
+            "example": "In order to get you services, please contact us at..",
+            "description": "The text to be delivered to the customer after payment for a service"
+          },
+          "stock_delimiter": {
+            "type": "string",
+            "example": ",",
+            "description": "How to delimit the stock if product type is SERIALS, for example with stock_delimiter \",\" and serials value first,second; the stock would have two different serials \"first\" and \"second\"."
+          },
+          "stock": {
+            "type": "integer",
+            "example": -1,
+            "description": "Stock of the current product, can be -1 for unlimited stock."
+          },
+          "dynamic_webhook": {
+            "type": "object",
+            "example": null
+          },
+          "bestseller": {
+            "type": "number",
+            "example": "0",
+            "description": "DEPRECATED"
+          },
+          "sort_priority": {
+            "type": "integer",
+            "example": 1,
+            "description": "Sort order of this product."
+          },
+          "unlisted": {
+            "type": "boolean",
+            "example": false,
+            "description": "If unlisted is true, the product is not shown in the storefront but can be bought through a direct link."
+          },
+          "on_hold": {
+            "type": "boolean",
+            "example": false,
+            "description": "If on_hold is true, the product cannot be bought but is shown in the storefront."
+          },
+          "terms_of_service": {
+            "type": "string",
+            "example": null,
+            "description": "Text containing the product's terms of service."
+          },
+          "warranty": {
+            "type": "integer",
+            "example": 86400,
+            "description": "Time, in seconds, of how much the warranty for this product lasts."
+          },
+          "warranty_text": {
+            "type": "string",
+            "example": "This warranty covers..",
+            "description": "Clear explanation of what the warranty covers."
+          },
+          "watermark_enabled": {
+            "type": "number",
+            "example": 1,
+            "description": "Whether sellix should add a watermark to your product image."
+          },
+          "watermark_text": {
+            "type": "string",
+            "example": "Sellix",
+            "description": "The watermark to add to the product image."
+          },
+          "redirect_link": {
+            "type": "string",
+            "example": "https://sellix.io",
+            "description": "The url to redirect a customer to on successful payment"
+          },
+          "label_singular": {
+            "type": "string",
+            "example": null
+          },
+          "label_plural": {
+            "type": "string",
+            "example": null
+          },
+          "private": {
+            "type": "boolean",
+            "example": false,
+            "description": "If private is true, the product is hidden on the storefront and cannot be bought with a direct link."
+          },
+          "created_at": {
+            "type": "integer",
+            "format": "timestamp",
+            "example": 162857125819,
+            "description": "Timestamp for the creation of the product."
+          },
+          "updated_at": {
+            "type": "integer",
+            "format": "timestamp",
+            "example": 162857125819,
+            "description": "Date, available if the product has been edited."
+          },
+          "updated_by": {
+            "type": "integer",
+            "example": 987,
+            "description": "User ID, available if the product has been edited."
+          },
+          "marketplace_category_id": {
+            "type": "string",
+            "example": "0",
+            "description": "The category ID the product is a part of"
+          },
+          "telegram_group_id": {
+            "type": "string",
+            "example": "none",
+            "description": "The Telegram group ID"
+          },
+          "telegram_integration": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Whether or not the Telegram integration is enabled"
+          },
+          "telegram_optional": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Whether or not the Telegram integration is optional"
+          },
+          "name": {
+            "type": "string",
+            "example": "Sellix",
+            "description": "The name of the product"
+          },
+          "image_name": {
+            "type": "string",
+            "example": "SellixImageName.png",
+            "description": "DEPRECATED: The name of the product image with the file type"
+          },
+          "image_storage": {
+            "type": "string",
+            "example": "PRODUCTS",
+            "description": "Where the image is stored in Sellix's self-hosted CDN."
+          },
+          "cloudflare_image_id": {
+            "$ref": "#/components/schemas/cloudflare_image_id"
+          },
+          "image_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/image_attachment"
+            }
+          },
+          "feedback": {
+            "type": "object",
+            "properties": {
+              "total": {
+                "type": "integer",
+                "example": 10,
+                "description": "Count of all the feedback."
+              },
+              "positive": {
+                "type": "integer",
+                "example": 8,
+                "description": "Count of positive feedback."
+              },
+              "neutral": {
+                "type": "integer",
+                "example": 1,
+                "description": "Count of neutral feedback."
+              },
+              "negative": {
+                "type": "integer",
+                "example": 1,
+                "description": "Count of negative feedback."
+              },
+              "numbers": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "integer"
+                },
+                "example": {
+                  "5": 6,
+                  "4": 2,
+                  "3": 1,
+                  "1": 1
+                }
+              },
+              "list": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "score": {
+                      "type": "number",
+                      "example": 5
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Nice product!"
+                    },
+                    "reply": {
+                      "type": "string",
+                      "example": "Thank you for the feedback."
+                    },
+                    "created_at": {
+                      "type": "integer",
+                      "format": "timestamp",
+                      "example": 162857125819,
+                      "description": "Timestamp for the creation of the feedback."
+                    },
+                    "updated_at": {
+                      "type": "number",
+                      "example": 162857125819
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "categories": {
+            "type": "array",
+            "items": {
+              "properties": {
+                "title": {
+                  "type": "string",
+                  "example": "Test Category",
+                  "description": "The title of the category"
+                },
+                "uniqid": {
+                  "type": "string",
+                  "example": "sample29a0e39d",
+                  "description": "The unique id of the category"
+                }
+              }
+            }
+          },
+          "payment_gateways_fees": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer",
+                  "example": 987
+                },
+                "shop_id": {
+                  "type": "integer",
+                  "example": 987,
+                  "description": "The shop ID to which this resource belongs."
+                },
+                "gateway": {
+                  "type": "string",
+                  "enum": [
+                    "PAYPAL",
+                    "STRIPE",
+                    "SKRILL",
+                    "PERFECT_MONEY",
+                    "CASH_APP",
+                    "BINANCE",
+                    "BITCOIN",
+                    "LITECOIN",
+                    "ETHEREUM",
+                    "BITCOIN_CASH",
+                    "NANO",
+                    "MONERO",
+                    "SOLANA",
+                    "RIPPLE",
+                    "BINANCE_COIN",
+                    "USDC:ERC20",
+                    "USDC:BEP20",
+                    "USDC:MATIC",
+                    "USDC:SOL",
+                    "USDT:ERC20",
+                    "USDT:BEP20",
+                    "USDT:MATIC",
+                    "USDT:SOL",
+                    "USDT:TRC20",
+                    "TRON",
+                    "BITCOIN_LN",
+                    "CONCORDIUM",
+                    "POLYGON",
+                    "PEPE:ERC20",
+                    "DAI:ERC20",
+                    "DAI:BEP20",
+                    "DAI:MATIC",
+                    "WETH:BEP20",
+                    "WETH:MATIC",
+                    "APE:ERC20",
+                    "APE:MATIC",
+                    "SHIB:ERC20",
+                    "SHIB:BEP20",
+                    "SHIB:MATIC",
+                    "USDC_NATIVE:MATIC",
+                    "DOGECOIN",
+                    "PYTH:SOL",
+                    "BONK:SOL",
+                    "JUP:SOL",
+                    "JITO:SOL",
+                    "WEN:SOL",
+                    "RENDER:SOL",
+                    "MOBILE:SOL",
+                    "HNT:SOL"
+                  ],
+                  "example": "STRIPE"
+                },
+                "percent_amount": {
+                  "type": "integer",
+                  "example": -5
+                },
+                "fixed_amount": {
+                  "type": "integer",
+                  "example": "0"
+                },
+                "fixed_currency": {
+                  "$ref": "#/components/schemas/currency"
+                },
+                "active_type": {
+                  "type": "string",
+                  "enum": ["PERCENT", "FIXED"],
+                  "example": "null",
+                  "description": "DEPRECATED"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "example": "1970-01-01 00:00:00"
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "example": "1975-02-28 00:00:00",
+                  "description": "Datetime for the creation of the resource"
+                }
+              }
+            }
+          },
+          "price_conversions": {
+            "type": "object", 
+            "properties": {
+              "AUD": {
+                "type": "number",
+                "example": 92.08,
+                "description": "The price of the product variant in AUD."
+              },
+              "BGN": {
+                "type": "number",
+                "example": 108.62,
+                "description": "The price of the product variant in BGN."
+              },
+              "BRL": {
+                "type": "number",
+                "example": 300.17,
+                "description": "The price of the product variant in BRL."
+              },
+              "ZAR": {
+                "type": "number",
+                "example": 1143.49,
+                "description": "The price of the product variant in ZAR."
+              },
+              "crypto": {
+                "type": "object",
+                "properties": {
+                  "APE": {
+                    "type": "string",
+                    "example": "31.0607029506",
+                    "description": "The price of the product variant in APE."
+                  },
+                  "BCH": {
+                    "type": "string",
+                    "example": "0.1271212408",
+                    "description": "The price of the product variant in BCH."
+                  },
+                  "BNB": {
+                    "type": "string",
+                    "example": "0.1067436987",
+                    "description": "The price of the product variant in BNB."
+                  },
+                  "USDC_NATIVE": {
+                    "type": "string",
+                    "example": "60.0000000000",
+                    "description": "The price of the product variant in USDC_NATIVE."
+                  }
+                },
+                "description": "A list of the price of the product variant in various cryptocurrencies."
+              }
+            }
+          },
+          "country_regulations": {
+            "type": "string",
+            "example": "IT",
+            "description": "The country ISO code that the business is located in"
+          },
+          "available_stripe_apm": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "example": "afterpay_clearpay"
+              },
+              "name": {
+                "type": "string",
+                "example": "Afterpay and Clearpay"
+              }
+            }
+          },
+          "serials": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": []
+          },
+          "webhooks": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": []
+          },
+          "theme": {
+            "type": "string",
+            "example": "dark",
+            "description": "The current theme enabled on the Sellix storefront"
+          },
+          "dark_mode": {
+            "type": "integer",
+            "enum": [0, 1],
+            "example": 1,
+            "description": "Whether or not dark mode is enabled on the Sellix storefront"
+          },
+          "vat_percentage": {
+            "type": "string",
+            "example": "0.00",
+            "description": "The VAR percentage set for the store"
+          },
+          "tax_details": {
+            "type": "object",
+            "properties": {
+              "vat_percentage": {
+                "type": "string",
+                "example": "0.00"
+              },
+              "tax_configuration": {
+                "type": "string",
+                "example": "NONE"
+              },
+              "tax_configuration_data": {
+                "type": "array",
+                "example": []
+              },
+              "display_tax_on_storefront": {
+                "type": "integer",
+                "enum": [0, 1],
+                "example": 0
+              },
+              "display_tax_custom_fields": {
+                "type": "integer",
+                "enum": [0, 1],
+                "example": 0
+              },
+              "validation_only_for_companies": {
+                "type": "integer",
+                "enum": [0, 1],
+                "example": 1
+              },
+              "validate_vat_number": {
+                "type": "integer",
+                "enum": [0, 1],
+                "example": 0
+              },
+              "prices_tax_inclusive": {
+                "type": "integer",
+                "enum": [0, 1],
+                "example": 0
+              }
+            }
+          },
+          "image_attachment_info": {
+            "$ref": "#/components/schemas/image_attachment"
+          },
+          "average_score": {
+            "type": "string",
+            "example": "5.0000",
+            "description": "The average rating of the product."
+          },
+          "sold_count": {
+            "type": "number",
+            "example": 236,
+            "description": "The amount of sales for the product."
+          },
+          "addons": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer",
+                  "example": 987
+                },
+                "uniqid": {
+                  "type": "string",
+                  "example": "sample29a0e39d"
+                },
+                "shop_id": {
+                  "type": "integer",
+                  "example": 987,
+                  "description": "The shop ID to which this resource belongs."
+                },
+                "product_types": {
+                  "type": "array",
+                  "example": null
+                },
+                "title": {
+                  "type": "string",
+                  "example": "Sellix"
+                },
+                "description": {
+                  "type": "string",
+                  "example": "A Sellix product description"
+                },
+                "price": {
+                  "type": "string",
+                  "example": "1.00"
+                },
+                "currency": {
+                  "$ref": "#/components/schemas/currency"
+                }
+              }
+            }
+          }
+        }
+      },
+      "product_addons": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer",
+              "example": 987
+            },
+            "uniqid": {
+              "type": "string",
+              "example": "sample29a0e39d"
+            },
+            "shop_id": {
+              "type": "integer",
+              "example": 987,
+              "description": "The shop ID to which this addon belongs."
+            },
+            "product_types": {
+              "type": "array",
+              "example": null
+            },
+            "title": {
+              "type": "string",
+              "example": "Sellix"
+            },
+            "description": {
+              "type": "string",
+              "example": "A Sellix product description"
+            },
+            "price": {
+              "type": "string",
+              "example": "1.00"
+            },
+            "currency": {
+              "$ref": "#/components/schemas/currency"
+            }
+          }
+        }
+      },
+      "product_download": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "example": 1,
+            "description": "ID of the resource."
+          },
+          "invoice_id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "sample-3ddfc9dc3d-ab2e3",
+            "description": "Unique ID of the invoice this download is linked to."
+          },
+          "customer_ip": {
+            "type": "string",
+            "example": "182.219.207.39",
+            "description": "The IP of the customer that downloaded the product."
+          },
+          "customer_isp": {
+            "type": "string",
+            "example": "WINDTRE",
+            "description": "The ISP of the customer that downloaded the product."
+          },
+          "customer_timezone": {
+            "type": "string",
+            "example": "GMT+1",
+            "description": "The timezone of the customer that downloaded the product."
+          },
+          "customer_country": {
+            "type": "string",
+            "example": "IT",
+            "description": "The country of the customer that downloaded the product."
+          },
+          "created_at": {
+            "type": "integer",
+            "format": "timestamp",
+            "example": 162857125819,
+            "description": "Timestamp, available if the download has been created."
+          }
+        }
+      },
+      "product_variant": {
+        "type": "object",
+        "properties": {
+          "price": { 
+            "type": "number",
+            "example": 60,
+            "description": "The price of the product variant."
+          },
+          "title": { 
+            "type": "string",
+            "example": "exampleTitle",
+            "description": "The title of the product variant."
+          },
+          "description": { 
+            "type": "string",
+            "example": "exampleDescription",
+            "description": "The description of the product variant."
+          },
+          "price_conversions": {
+            "type": "object", 
+            "properties": {
+              "AUD": {
+                "type": "number",
+                "example": 92.08,
+                "description": "The price of the product variant in AUD."
+              },
+              "BGN": {
+                "type": "number",
+                "example": 108.62,
+                "description": "The price of the product variant in BGN."
+              },
+              "BRL": {
+                "type": "number",
+                "example": 300.17,
+                "description": "The price of the product variant in BRL."
+              },
+              "ZAR": {
+                "type": "number",
+                "example": 1143.49,
+                "description": "The price of the product variant in ZAR."
+              },
+              "crypto": {
+                "type": "object",
+                "properties": {
+                  "APE": {
+                    "type": "string",
+                    "example": "31.0607029506",
+                    "description": "The price of the product variant in APE."
+                  },
+                  "BCH": {
+                    "type": "string",
+                    "example": "0.1271212408",
+                    "description": "The price of the product variant in BCH."
+                  },
+                  "BNB": {
+                    "type": "string",
+                    "example": "0.1067436987",
+                    "description": "The price of the product variant in BNB."
+                  },
+                  "USDC_NATIVE": {
+                    "type": "string",
+                    "example": "60.0000000000",
+                    "description": "The price of the product variant in USDC_NATIVE."
+                  }
+                },
+                "description": "A list of the price of the product variant in various cryptocurrencies."
+              }
+            }
+          }
+        },
+        "description": "Product variant object."
+      },
       "query": {
         "type": "object",
         "properties": {
@@ -8582,698 +10009,524 @@
           }
         }
       },
-      "cloudflare_image_id": {
-        "type": "string",
-        "example": "sample-c4f1-4f7c-9a1d-89120ed0c800",
-        "description": "New field containing the cloudflare image ID of this product, replaces image_attachment and image_name. Format https://imagedelivery.net/95QNzrEeP7RU5l5WdbyrKw/<cloudflare_image_id>/<variant_name> where variant_name can be shopItem, avatar, icon, imageAvatarFeedback, public, productImageCart."
-      },
-      "crypto_transaction": {
-        "type": "object",
-        "properties": {
-          "crypto_amount": {
-            "type": "number",
-            "format": "double",
-            "example": 0.014174,
-            "description": "Crypto amount sent in the transaction."
-          },
-          "hash": {
-            "type": "string",
-            "example": "234dB62Q3X9nyqussRSHW5x9rXe7NzyS3hLcwSTtzd9WLWfrHFUtX4KS6DAMyyHnvRgUNiqUvZdw2T9XWJqa8sPW",
-            "description": "Crypto transaction hash."
-          },
-          "confirmations": {
-            "type": "integer",
-            "example": 1,
-            "description": "Crypto transaction confirmations, not updated once the invoice status is COMPLETED or VOIDED."
-          },
-          "created_at": {
-            "type": "integer",
-            "format": "timestamp",
-            "example": 162857125819,
-            "description": "Timestamp for the crypto transaction reception date"
-          },
-          "updated_at": {
-            "type": "integer",
-            "example": 1640673134,
-            "description": "Crypto transaction update date."
-          },
-          "aml_tx": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "integer",
-                "example": 987,
-                "description": "AML transaction ID."
-              },
-              "shop_id": {
-                "type": "integer",
-                "example": 987,
-                "description": "Shop ID linked to this AML transaction."
-              },
-              "invoice_id": {
-                "type": "string",
-                "example": "1c7fa9-a277075d5d-6d8431",
-                "description": "Unique ID of the invoice this AML transaction is linked to."
-              },
-              "origin": {
-                "type": "string",
-                "example": "INVOICE",
-                "description": "Origin of the AML transaction."
-              },
-              "type": {
-                "type": "string",
-                "example": "TRANSACTION",
-                "description": "Type of the AML transaction."
-              },
-              "asset": {
-                "type": "string",
-                "example": "holistic",
-                "description": "Asset of the AML transaction."
-              },
-              "blockchain": {
-                "type": "string",
-                "example": "holistic",
-                "description": "Blockchain of the AML transaction."
-              },
-              "hash": {
-                "type": "string",
-                "example": "df6693ca6fe386993ff8496fa297df1f2fcd8ce65bd45468dd1539f16d949ee7",
-                "description": "AML transaction hash."
-              },
-              "output_type": {
-                "type": "string",
-                "example": "address",
-                "description": "AML transaction output type."
-              },
-              "output_address": {
-                "type": "string",
-                "example": "bc1q5k8c3w7js7s56mhremysa7mv9ufsr59eers9ad",
-                "description": "AML transaction output address."
-              },
-              "risk_score": {
-                "type": "string",
-                "example": "0.270000",
-                "description": "AML transaction risk score."
-              },
-              "asset_list": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "example": [
-                  "BTC/bitcoin"
-                ],
-                "description": "AML transaction asset list."
-              },
-              "error": {
-                "type": "string",
-                "example": null,
-                "description": "AML transaction error."
-              },
-              "evaluation_detail": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "example": [],
-                "description": "AML transaction evaluation detail."
-              },
-              "contributions": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "entities": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "name": {
-                            "type": "string",
-                            "example": "Coinbase",
-                            "description": "Entity name."
-                          },
-                          "is_vasp": {
-                            "type": "boolean",
-                            "example": true,
-                            "description": "Is a VASP."
-                          },
-                          "actor_id": {
-                            "type": "integer",
-                            "example": 30,
-                            "description": "Actor ID."
-                          },
-                          "category": {
-                            "type": "string",
-                            "example": "Exchange",
-                            "description": "Entity category."
-                          },
-                          "is_primary_entity": {
-                            "type": "boolean",
-                            "example": true,
-                            "description": "Is the primary entity."
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              },
-              "blockchain_info": {
-                "type": "object",
-                "properties": {
-                  "address": {
-                    "type": "object",
-                    "properties": {
-                      "has_sent": {
-                        "type": "boolean",
-                        "example": true,
-                        "description": "Has sent."
-                      },
-                      "has_received": {
-                        "type": "boolean",
-                        "example": true,
-                        "description": "Has received."
-                      }
-                    }
-                  },
-                  "transaction": {
-                    "type": "object",
-                    "properties": {
-                      "time": {
-                        "type": "string",
-                        "example": "1975-02-28T22:05:25Z",
-                        "description": "Transaction time."
-                      },
-                      "value": {
-                        "type": "object",
-                        "properties": {
-                          "usd": {
-                            "type": "number",
-                            "format": "double",
-                            "example": 806.035089,
-                            "description": "Transaction value in USD."
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              },
-              "cluster_entities": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "name": {
-                      "type": "string",
-                      "example": "Unknown",
-                      "description": "Entity name."
-                    },
-                    "is_vasp": {
-                      "type": "boolean",
-                      "example": null,
-                      "description": "Is a VASP."
-                    },
-                    "actor_id": {
-                      "type": "integer",
-                      "example": -4,
-                      "description": "Actor ID."
-                    },
-                    "category": {
-                      "type": "string",
-                      "example": "Unknown",
-                      "description": "Entity category."
-                    },
-                    "is_primary_entity": {
-                      "type": "boolean",
-                      "example": true,
-                      "description": "Is the primary entity."
-                    },
-                    "is_after_sanction_date": {
-                      "type": "boolean",
-                      "example": false,
-                      "description": "Is after the sanction date."
-                    }
-                  }
-                }
-              },
-              "risk_score_detail": {
-                "type": "object",
-                "properties": {
-                  "source": {
-                    "type": "number",
-                    "format": "double",
-                    "example": 0.15692119477282407,
-                    "description": "Source risk score."
-                  },
-                  "destination": {
-                    "type": "number",
-                    "format": "double",
-                    "example": 0.15692119477282407,
-                    "description": "Destination risk score."
-                  }
-                }
-              },
-              "created_at": {
-                "type": "integer",
-                "format": "timestamp",
-                "example": 162857125819,
-                "description": "Timestamp for the AML transaction creation date"
-              }
-            }
-          }
-        }
-      },
-      "aml_wallet": {
+      "subscription": {
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
-            "example": 987,
-            "description": "AML transaction ID."
+            "type": "string",
+            "description": "ID of the subscription.",
+            "example": "rec_sample-3afde4b6e1-82833e"
           },
           "shop_id": {
             "type": "integer",
-            "example": 987,
-            "description": "Shop ID linked to this AML transaction."
+            "example": 124,
+            "description": "The shop ID to which this subscription belongs."
           },
-          "invoice_id": {
+          "product_id": {
             "type": "string",
-            "example": "sample-3ddfc9dc3d-ab2e36",
-            "description": "Unique ID of the invoice this AML transaction is linked to."
+            "description": "ID of the product subscription.",
+            "example": "samplede6277597"
           },
-          "origin": {
+          "status": {
             "type": "string",
-            "example": "INVOICE",
-            "description": "Origin of the AML transaction."
-          },
-          "type": {
-            "type": "string",
-            "example": "WALLET",
-            "description": "Type of the AML transaction."
-          },
-          "asset": {
-            "type": "string",
-            "example": "holistic",
-            "description": "Asset of the AML transaction."
-          },
-          "blockchain": {
-            "type": "string",
-            "example": "holistic",
-            "description": "Blockchain of the AML transaction."
-          },
-          "hash": {
-            "type": "string",
-            "example": "bc1qvkwfapml56vvweuvvp7tqvurv2w52asv38u5l3",
-            "description": "AML transaction hash."
-          },
-          "output_type": {
-            "type": "string",
-            "example": null,
-            "description": "AML transaction output type."
-          },
-          "output_address": {
-            "type": "string",
-            "example": null,
-            "description": "AML transaction output address."
-          },
-          "risk_score": {
-            "type": "string",
-            "example": "0.156921",
-            "description": "AML transaction risk score."
-          },
-          "asset_list": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "example": [
-              "BTC/bitcoin"
+            "description": "Subscription status.",
+            "enum": [
+              "PENDING",
+              "CANCELED",
+              "TRIALING",
+              "ACTIVE"
             ],
-            "description": "AML transaction asset list."
+            "example": "CANCELED"
           },
-          "error": {
+          "gateway": {
             "type": "string",
-            "example": null,
-            "description": "AML transaction error."
+            "enum": [
+              "PAYPAL",
+              "STRIPE",
+              "SKRILL",
+              "PERFECT_MONEY",
+              "CASH_APP",
+              "BINANCE",
+              "BITCOIN",
+              "LITECOIN",
+              "ETHEREUM",
+              "BITCOIN_CASH",
+              "NANO",
+              "MONERO",
+              "SOLANA",
+              "RIPPLE",
+              "BINANCE_COIN",
+              "USDC:ERC20",
+              "USDC:BEP20",
+              "USDC:MATIC",
+              "USDC:SOL",
+              "USDT:ERC20",
+              "USDT:BEP20",
+              "USDT:MATIC",
+              "USDT:SOL",
+              "USDT:TRC20",
+              "TRON",
+              "BITCOIN_LN",
+              "CONCORDIUM",
+              "POLYGON",
+              "PEPE:ERC20",
+              "DAI:ERC20",
+              "DAI:BEP20",
+              "DAI:MATIC",
+              "WETH:BEP20",
+              "WETH:MATIC",
+              "APE:ERC20",
+              "APE:MATIC",
+              "SHIB:ERC20",
+              "SHIB:BEP20",
+              "SHIB:MATIC",
+              "USDC_NATIVE:MATIC",
+              "DOGECOIN",
+              "PYTH:SOL",
+              "BONK:SOL",
+              "JUP:SOL",
+              "JITO:SOL",
+              "WEN:SOL",
+              "RENDER:SOL",
+              "MOBILE:SOL",
+              "HNT:SOL"
+            ],
+            "example": "STRIPE",
+            "description": "Gateway chosen for this subscription. A new invoice monthly will be created using this gayeway."
           },
-          "evaluation_detail": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "rule_id": {
-                        "type": "string",
-                        "example": "2a380f72-2dcd-4b90-9467-d3c7b6d25dfb",
-                        "description": "Rule ID."
-                      },
-                      "rule_name": {
-                        "type": "string",
-                        "example": "Sanctioned, TF & CSAM",
-                        "description": "Rule name."
-                      },
-                      "risk_score": {
-                        "type": "number",
-                        "format": "double",
-                        "example": 0.014195487896676929,
-                        "description": "Risk score."
-                      },
-                      "matched_elements": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "category": {
-                              "type": "string",
-                              "example": "OFAC Sanctioned Entity",
-                              "description": "Category."
-                            },
-                            "contributions": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "entity": {
-                                    "type": "string",
-                                    "example": "Lazarus Group Harmony Horizon Bridge Exploit - June 2022 (suspected post-Exchange)",
-                                    "description": "Entity."
-                                  },
-                                  "risk_triggers": {
-                                    "type": "object",
-                                    "properties": {
-                                      "country": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "string"
-                                        }
-                                      },
-                                      "category": {
-                                        "type": "string",
-                                        "example": "OFAC Sanctioned Entity",
-                                        "description": "Category."
-                                      },
-                                      "category_id": {
-                                        "type": "string",
-                                        "example": "8d39eacf-a5c0-4b38-a101-6b3120b84bf9",
-                                        "description": "Category ID."
-                                      },
-                                      "is_sanctioned": {
-                                        "type": "boolean",
-                                        "example": true,
-                                        "description": "Is sanctioned."
-                                      }
-                                    }
-                                  },
-                                  "contribution_value": {
-                                    "type": "object",
-                                    "properties": {
-                                      "usd": {
-                                        "type": "number",
-                                        "format": "double",
-                                        "example": 15.554924625314328,
-                                        "description": "Contribution value in USD."
-                                      }
-                                    }
-                                  },
-                                  "contribution_percentage": {
-                                    "type": "number",
-                                    "format": "double",
-                                    "example": 0.09531445633497328,
-                                    "description": "Contribution percentage."
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
+          "custom_fields": {
+            "$ref": "#/components/schemas/custom_fields_object"
           },
-          "contributions": {
-            "type": "object",
-            "properties": {
-              "source": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "entities": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "name": {
-                            "type": "string",
-                            "example": "Unknown",
-                            "description": "Entity name."
-                          },
-                          "is_vasp": {
-                            "type": "boolean",
-                            "example": null,
-                            "description": "Is a VASP."
-                          },
-                          "actor_id": {
-                            "type": "integer",
-                            "example": -4,
-                            "description": "Actor ID."
-                          },
-                          "category": {
-                            "type": "string",
-                            "example": "Unknown",
-                            "description": "Entity category."
-                          },
-                          "is_primary_entity": {
-                            "type": "boolean",
-                            "example": true,
-                            "description": "Is the primary entity."
-                          }
-                        }
-                      }
-                    },
-                    "contribution_value": {
-                      "type": "object",
-                      "properties": {
-                        "usd": {
-                          "type": "number",
-                          "format": "double",
-                          "example": 8842.310699142721,
-                          "description": "Contribution value in USD."
-                        }
-                      }
-                    },
-                    "contribution_percentage": {
-                      "type": "number",
-                      "format": "double",
-                      "example": 54.1822,
-                      "description": "Contribution percentage."
-                    }
-                  }
-                }
-              },
-              "destination": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "entities": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "name": {
-                            "type": "string",
-                            "example": "Kraken",
-                            "description": "Entity name."
-                          },
-                          "is_vasp": {
-                            "type": "boolean",
-                            "example": true,
-                            "description": "Is a VASP."
-                          },
-                          "actor_id": {
-                            "type": "integer",
-                            "example": 23,
-                            "description": "Actor ID."
-                          },
-                          "category": {
-                            "type": "string",
-                            "example": "Exchange",
-                            "description": "Entity category."
-                          },
-                          "is_primary_entity": {
-                            "type": "boolean",
-                            "example": true,
-                            "description": "Is the primary entity."
-                          }
-                        }
-                      }
-                    },
-                    "contribution_value": {
-                      "type": "object",
-                      "properties": {
-                        "usd": {
-                          "type": "number",
-                          "format": "double",
-                          "example": 14645.819876,
-                          "description": "Contribution value in USD."
-                        }
-                      }
-                    },
-                    "contribution_percentage": {
-                      "type": "number",
-                      "format": "double",
-                      "example": 100,
-                      "description": "Contribution percentage."
-                    }
-                  }
-                }
-              }
-            }
+          "customer_id": {
+            "type": "string",
+            "description": "ID of the store's customer.",
+            "example": "cst_sample6addc898a645"
           },
-          "blockchain_info": {
-            "type": "object",
-            "properties": {
-              "cluster": {
-                "type": "object",
-                "properties": {
-                  "inflow_value": {
-                    "type": "object",
-                    "properties": {
-                      "usd": {
-                        "type": "number",
-                        "format": "double",
-                        "example": 16319.573922305124,
-                        "description": "Inflow value in USD."
-                      }
-                    }
-                  },
-                  "outflow_value": {
-                    "type": "object",
-                    "properties": {
-                      "usd": {
-                        "type": "number",
-                        "format": "double",
-                        "example": 14645.819876,
-                        "description": "Inflow value in USD."
-                      }
-                    }
-                  }
-                }
-              }
-            }
+          "stripe_customer_id": {
+            "type": "string",
+            "description": "ID of the customer created on STRIPE.",
+            "example": "cus_samplegIE0YKwapE6"
           },
-          "cluster_entities": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "example": "Unknown",
-                  "description": "Entity name."
-                },
-                "is_vasp": {
-                  "type": "boolean",
-                  "example": null,
-                  "description": "Is a VASP."
-                },
-                "actor_id": {
-                  "type": "integer",
-                  "example": -4,
-                  "description": "Actor ID."
-                },
-                "category": {
-                  "type": "string",
-                  "example": "Unknown",
-                  "description": "Entity category."
-                },
-                "is_primary_entity": {
-                  "type": "boolean",
-                  "example": true,
-                  "description": "Is the primary entity."
-                },
-                "is_after_sanction_date": {
-                  "type": "boolean",
-                  "example": false,
-                  "description": "Is after the sanction date."
-                }
-              }
-            }
+          "stripe_account": {
+            "type": "string",
+            "description": "ID of the Stripe connected account.",
+            "example": "acct_sampleuMKb2X7rAeMb"
           },
-          "risk_score_detail": {
-            "type": "object",
-            "properties": {
-              "source": {
-                "type": "number",
-                "format": "double",
-                "example": 0.15692119477282407,
-                "description": "Source risk score."
-              },
-              "destination": {
-                "type": "number",
-                "format": "double",
-                "example": 0.15692119477282407,
-                "description": "Destination risk score."
-              }
-            }
+          "stripe_subscription_id": {
+            "type": "string",
+            "description": "ID of the Stripe subscription.",
+            "example": "sub_samplexpKb2X7rAeMbKdJc78AP"
+          },
+          "coupon_id": {
+            "type": "string",
+            "description": "If a coupon has been applied, its ID.",
+            "example": null
+          },
+          "current_period_end": {
+            "type": "integer",
+            "format": "timestamp",
+            "description": "When the current billing period will end.",
+            "example": 1641313649
+          },
+          "upcoming_email_1_week_sent": {
+            "type": "boolean",
+            "description": "Whether or not the email for an upcoming renewal has been sent.",
+            "example": false
+          },
+          "trial_period_ending_email_sent": {
+            "type": "boolean",
+            "description": "Whether or not the email for the trial period expiring has been sent.",
+            "example": false
+          },
+          "renewal_invoice_created": {
+            "type": "boolean",
+            "description": "If true, the renewal invoice has already been created.",
+            "example": false
           },
           "created_at": {
             "type": "integer",
             "format": "timestamp",
             "example": 162857125819,
-            "description": "Timestamp for the AML transaction creation date."
+            "description": "Timestamp for the creation of the subscription."
+          },
+          "updated_at": {
+            "type": "integer",
+            "format": "timestamp",
+            "description": "When this subscription was last updated.",
+            "example": 1641315120
+          },
+          "canceled_at": {
+            "type": "integer",
+            "format": "timestamp",
+            "description": "When this subscription was canceled.",
+            "example": null
+          },
+          "product_title": {
+            "type": "string",
+            "description": "Digital Software",
+            "example": "The title of the product for this subscription."
+          },
+          "customer_name": {
+            "type": "string",
+            "description": "Customer name.",
+            "example": "James"
+          },
+          "customer_surname": {
+            "type": "string",
+            "description": "Customer surname.",
+            "example": "Smith"
+          },
+          "customer_phone": {
+            "type": "string",
+            "description": "Customer phone.",
+            "example": null
+          },
+          "customer_phone_country_code": {
+            "type": "string",
+            "description": "Customer phone country code.",
+            "example": null
+          },
+          "customer_country_code": {
+            "type": "string",
+            "description": "Customer country code.",
+            "example": null
+          },
+          "customer_street_address": {
+            "type": "string",
+            "description": "Customer street address.",
+            "example": null
+          },
+          "customer_additional_address_info": {
+            "type": "string",
+            "description": "Customer street address additional info.",
+            "example": null
+          },
+          "customer_city": {
+            "type": "string",
+            "description": "Customer city.",
+            "example": null
+          },
+          "customer_postal_code": {
+            "type": "string",
+            "description": "Customer postal code.",
+            "example": null
+          },
+          "customer_state": {
+            "type": "string",
+            "description": "Customer state.",
+            "example": null
+          },
+          "customer_email": {
+            "type": "string",
+            "description": "Customer email.",
+            "example": "sample@gmail.com"
+          },
+          "invoices": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/invoiceListing"
+            }
           }
         }
       },
-      "invoice_status": {
+      "subscription_invoice_response": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "integer",
+            "example": 200
+          },
+          "data": {
+            "type": "object",
+            "required": [
+              "url",
+              "uniqid"
+            ],
+            "properties": {
+              "url": {
+                "type": "string",
+                "description": "Sellix hosted payment page."
+              },
+              "uniqid": {
+                "type": "string",
+                "format": "uuid",
+                "description": "Unique ID of the invoice created for the subscription."
+              }
+            },
+            "example": {
+              "url": "https://sellix.io/payment/sample-4caac117ca-abeb80",
+              "uniqid": "sample-4caac117ca-abeb80"
+            }
+          },
+          "error": {
+            "type": "string",
+            "example": null
+          },
+          "message": {
+            "type": "string",
+            "example": "<success-message>"
+          },
+          "env": {
+            "type": "string",
+            "example": "production"
+          },
+          "log": {
+            "type": "object",
+            "example": null
+          }
+        }
+      },
+      "subscription_trial_response": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "integer",
+            "example": 200
+          },
+          "data": {
+            "type": "object",
+            "required": [
+              "invoice"
+            ],
+            "properties": {
+              "subscription_id": {
+                "type": "string",
+                "description": "Subscription ID."
+              }
+            },
+            "example": {
+              "subscription_id": "rec_sample-4caac117ca-abeb80"
+            }
+          },
+          "error": {
+            "type": "string",
+            "example": null
+          },
+          "message": {
+            "type": "string",
+            "example": "<success-message>"
+          },
+          "env": {
+            "type": "string",
+            "example": "production"
+          },
+          "log": {
+            "type": "object",
+            "example": null
+          }
+        }
+      },
+      "subscriptionListing": {
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
-            "example": 10726392,
-            "description": "Unique ID of the invoice status."
-          },
-          "invoice_id": {
             "type": "string",
-            "example": "sample-3ddfc9dc3d-ab2e36",
-            "description": "Unique ID of the invoice this status is linked to."
+            "description": "ID of the subscription.",
+            "example": "rec_sample-3afde4b6e1-82833e"
+          },
+          "shop_id": {
+            "type": "integer",
+            "example": 124,
+            "description": "The shop ID to which this subscription belongs."
+          },
+          "product_id": {
+            "type": "string",
+            "description": "ID of the product subscription.",
+            "example": "samplede6277597"
           },
           "status": {
+            "type": "string",
+            "description": "Subscription status.",
             "enum": [
               "PENDING",
-              "COMPLETED",
-              "VOIDED",
-              "WAITING_FOR_CONFIRMATIONS",
-              "PARTIAL",
-              "CUSTOMER_DISPUTE_ONGOING",
-              "REVERSED",
-              "REFUNDED",
-              "WAITING_SHOP_ACTION",
-              "PROCESSING"
+              "CANCELED",
+              "TRIALING",
+              "ACTIVE"
             ],
-            "example": "COMPLETED",
-            "description": "Status of the invoice."
+            "example": "CANCELED"
           },
-          "details": {
+          "gateway": {
             "type": "string",
-            "example": "The invoice has been flagged as completed and the product has been shipped.",
-            "description": "Additional details on the status change."
+            "enum": [
+              "PAYPAL",
+              "STRIPE",
+              "SKRILL",
+              "PERFECT_MONEY",
+              "CASH_APP",
+              "BINANCE",
+              "BITCOIN",
+              "LITECOIN",
+              "ETHEREUM",
+              "BITCOIN_CASH",
+              "NANO",
+              "MONERO",
+              "SOLANA",
+              "RIPPLE",
+              "BINANCE_COIN",
+              "USDC:ERC20",
+              "USDC:BEP20",
+              "USDC:MATIC",
+              "USDC:SOL",
+              "USDT:ERC20",
+              "USDT:BEP20",
+              "USDT:MATIC",
+              "USDT:SOL",
+              "USDT:TRC20",
+              "TRON",
+              "BITCOIN_LN",
+              "CONCORDIUM",
+              "POLYGON",
+              "PEPE:ERC20",
+              "DAI:ERC20",
+              "DAI:BEP20",
+              "DAI:MATIC",
+              "WETH:BEP20",
+              "WETH:MATIC",
+              "APE:ERC20",
+              "APE:MATIC",
+              "SHIB:ERC20",
+              "SHIB:BEP20",
+              "SHIB:MATIC",
+              "USDC_NATIVE:MATIC",
+              "DOGECOIN",
+              "PYTH:SOL",
+              "BONK:SOL",
+              "JUP:SOL",
+              "JITO:SOL",
+              "WEN:SOL",
+              "RENDER:SOL",
+              "MOBILE:SOL",
+              "HNT:SOL"
+            ],
+            "example": "STRIPE",
+            "description": "Gateway chosen for this subscription. A new invoice monthly will be created using this gayeway."
+          },
+          "custom_fields": {
+            "$ref": "#/components/schemas/custom_fields_object"
+          },
+          "customer_id": {
+            "type": "string",
+            "description": "ID of the store's customer.",
+            "example": "cst_sample6addc898a645"
+          },
+          "stripe_customer_id": {
+            "type": "string",
+            "description": "ID of the customer created on STRIPE.",
+            "example": "cus_samplegIE0YKwapE6"
+          },
+          "stripe_account": {
+            "type": "string",
+            "description": "ID of the Stripe connected account.",
+            "example": "acct_sampleuMKb2X7rAeMb"
+          },
+          "stripe_subscription_id": {
+            "type": "string",
+            "description": "ID of the Stripe subscription.",
+            "example": "sub_samplexpKb2X7rAeMbKdJc78AP"
+          },
+          "coupon_id": {
+            "type": "string",
+            "description": "If a coupon has been applied, its ID.",
+            "example": null
+          },
+          "current_period_end": {
+            "type": "integer",
+            "format": "timestamp",
+            "description": "When the current billing period will end.",
+            "example": 1641313649
+          },
+          "upcoming_email_1_week_sent": {
+            "type": "boolean",
+            "description": "Whether or not the email for an upcoming renewal has been sent.",
+            "example": false
+          },
+          "trial_period_ending_email_sent": {
+            "type": "boolean",
+            "description": "Whether or not the email for the trial period expiring has been sent.",
+            "example": false
+          },
+          "renewal_invoice_created": {
+            "type": "boolean",
+            "description": "If true, the renewal invoice has already been created.",
+            "example": false
           },
           "created_at": {
             "type": "integer",
             "format": "timestamp",
             "example": 162857125819,
-            "description": "Timestamp for the status change date."
+            "description": "Timestamp for the creation of the subscription."
+          },
+          "updated_at": {
+            "type": "integer",
+            "format": "timestamp",
+            "description": "When this subscription was last updated.",
+            "example": 1641315120
+          },
+          "canceled_at": {
+            "type": "integer",
+            "format": "timestamp",
+            "description": "When this subscription was canceled.",
+            "example": null
+          },
+          "product_title": {
+            "type": "string",
+            "description": "Digital Software",
+            "example": "The title of the product for this subscription."
+          },
+          "customer_name": {
+            "type": "string",
+            "description": "Customer name.",
+            "example": "James"
+          },
+          "customer_surname": {
+            "type": "string",
+            "description": "Customer surname.",
+            "example": "Smith"
+          },
+          "customer_phone": {
+            "type": "string",
+            "description": "Customer phone.",
+            "example": null
+          },
+          "customer_phone_country_code": {
+            "type": "string",
+            "description": "Customer phone country code.",
+            "example": null
+          },
+          "customer_country_code": {
+            "type": "string",
+            "description": "Customer country code.",
+            "example": null
+          },
+          "customer_street_address": {
+            "type": "string",
+            "description": "Customer street address.",
+            "example": null
+          },
+          "customer_additional_address_info": {
+            "type": "string",
+            "description": "Customer street address additional info.",
+            "example": null
+          },
+          "customer_city": {
+            "type": "string",
+            "description": "Customer city.",
+            "example": null
+          },
+          "customer_postal_code": {
+            "type": "string",
+            "description": "Customer postal code.",
+            "example": null
+          },
+          "customer_state": {
+            "type": "string",
+            "description": "Customer state.",
+            "example": null
+          },
+          "customer_email": {
+            "type": "string",
+            "description": "Customer email.",
+            "example": "sample@gmail.com"
           }
         }
       },
@@ -9352,643 +10605,7 @@
           }
         }
       },
-      "ip_info": {
-        "type": "object",
-        "properties": {
-          "success": {
-            "type": "boolean",
-            "example": true,
-            "description": "IP info retrieved successfully."
-          },
-          "message": {
-            "type": "string",
-            "example": "Success",
-            "description": "Any other details linked to this IP."
-          },
-          "fraud_score": {
-            "type": "integer",
-            "maximum": 100,
-            "minimum": 987,
-            "example": 25,
-            "description": "IP Fraud Score details."
-          },
-          "country_code": {
-            "type": "string",
-            "example": "IT",
-            "description": "IP country code."
-          },
-          "region": {
-            "type": "string",
-            "example": "Emilia Romagna",
-            "description": "IP region."
-          },
-          "city": {
-            "type": "string",
-            "example": "Bologna",
-            "description": "IP city."
-          },
-          "ISP": {
-            "type": "string",
-            "example": "Telecom TIM",
-            "description": "IP ISP"
-          },
-          "ASN": {
-            "type": "integer",
-            "example": 308172,
-            "description": "ISP ASN"
-          },
-          "operating_system": {
-            "type": "string",
-            "example": "Mac 10.16",
-            "description": "Customer device operating system."
-          },
-          "browser": {
-            "type": "string",
-            "example": "Chrome 96.0",
-            "description": "Customer device browser."
-          },
-          "organization": {
-            "type": "string",
-            "example": "Telecom TIM",
-            "description": "IP organization."
-          },
-          "is_crawler": {
-            "type": "boolean",
-            "example": false,
-            "description": "If true, the IP has been recently detected as a crawler."
-          },
-          "timezone": {
-            "type": "string",
-            "example": "Europe/Rome",
-            "description": "Customer timezone."
-          },
-          "mobile": {
-            "type": "boolean",
-            "example": false,
-            "description": "If true, the customer used a mobile device."
-          },
-          "host": {
-            "type": "string",
-            "example": "cust.vodafonedsl.it",
-            "description": "ISP host."
-          },
-          "proxy": {
-            "type": "boolean",
-            "example": false,
-            "description": "If true, the IP has been recently detected using a proxy."
-          },
-          "vpn": {
-            "type": "boolean",
-            "example": false,
-            "description": "If true, the IP has been recently detected using a VPN."
-          },
-          "tor": {
-            "type": "boolean",
-            "example": false,
-            "description": "If true, the IP has been recently detected using TOR."
-          },
-          "active_vpn": {
-            "type": "boolean",
-            "example": false,
-            "description": "If true, the IP has an active VPN connection."
-          },
-          "active_tor": {
-            "type": "boolean",
-            "example": false,
-            "description": "If true, the IP has an active TOR connection."
-          },
-          "device_brand": {
-            "type": "string",
-            "example": "Apple",
-            "description": "Customer device brand."
-          },
-          "device_model": {
-            "type": "string",
-            "example": "N/A",
-            "description": "Customer device model."
-          },
-          "recent_abuse": {
-            "type": "boolean",
-            "example": false,
-            "description": "If true, the IP has been recently detected in an online abuse."
-          },
-          "bot_status": {
-            "type": "boolean",
-            "example": false,
-            "description": "If true, the IP has been recently detected as a BOT."
-          },
-          "connection_type": {
-            "type": "string",
-            "example": "Residential",
-            "description": "Customer connection type."
-          },
-          "abuse_velocity": {
-            "type": "string",
-            "example": "none",
-            "description": "IP abuse velocity."
-          },
-          "zip_code": {
-            "type": "string",
-            "example": "N/A",
-            "description": "If detected, customer ZIP code."
-          },
-          "latitude": {
-            "type": "number",
-            "format": "double",
-            "example": 1,
-            "description": "IP latitude."
-          },
-          "longitude": {
-            "type": "number",
-            "format": "double",
-            "example": 2,
-            "description": "IP longitude."
-          },
-          "request_id": {
-            "type": "string",
-            "example": "sampleN0vmX",
-            "description": "IP request ID used for internal reference."
-          }
-        },
-        "description": "Additional info on the customer IP."
-      },
-      "custom_fields_object": {
-        "type": "object",
-        "example": {
-          "username": "sellix-user"
-        },
-        "description": "key-value JSON having as key the custom field name and as value the custom field value inserted by the customer. Custom fields can both be used as inputs from the customers but also as metadata for invoices, letting you pass hidden fields for internal referencing."
-      },
-      "custom_fields_array": {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "text",
-                "hidden",
-                "number",
-                "largetextbox",
-                "checkbox"
-              ],
-              "example": "checkbox",
-              "description": "Type of the custom field."
-            },
-            "name": {
-              "type": "string",
-              "example": "Read the ToS",
-              "description": "Custom field name displayed to the customer."
-            },
-            "regex": {
-              "type": "string",
-              "example": null,
-              "description": "Regex that the custom field value must match."
-            },
-            "placeholder": {
-              "type": "string",
-              "example": null,
-              "description": "Placeholder for the custom field input."
-            },
-            "default": {
-              "type": "string",
-              "example": null,
-              "description": "Default value if the customer leaves the input empty."
-            },
-            "required": {
-              "type": "boolean",
-              "example": false,
-              "description": "Whether or not this custom field is required to proceed with the purchase."
-            }
-          }
-        }
-      },
-      "payment_response_white_label": {
-        "type": "object",
-        "properties": {
-          "status": {
-            "type": "integer",
-            "example": 200
-          },
-          "data": {
-            "type": "object",
-            "required": [
-              "invoice"
-            ],
-            "properties": {
-              "invoice": {
-                "$ref": "#/components/schemas/invoice"
-              }
-            },
-            "example": {
-              "invoice": {
-                "uniqid": "sample-4caac117ca-abeb80",
-                "...": null
-              }
-            }
-          },
-          "message": {
-            "type": "string",
-            "example": "<success-message>"
-          },
-          "log": {
-            "type": "object",
-            "example": null
-          },
-          "error": {
-            "type": "string",
-            "example": null
-          },
-          "env": {
-            "type": "string",
-            "example": "production"
-          }
-        }
-      },
-      "payment_response": {
-        "type": "object",
-        "properties": {
-          "status": {
-            "type": "integer",
-            "example": 200
-          },
-          "data": {
-            "type": "object",
-            "required": [
-              "url",
-              "uniqid"
-            ],
-            "properties": {
-              "url": {
-                "type": "string",
-                "description": "Sellix hosted payment page."
-              },
-              "uniqid": {
-                "type": "string",
-                "format": "uuid",
-                "description": "Unique ID of the invoice created for the payment."
-              }
-            },
-            "example": {
-              "url": "https://sellix.io/payment/sample-4caac117ca-abeb80",
-              "uniqid": "sample-4caac117ca-abeb80"
-            }
-          },
-          "error": {
-            "type": "string",
-            "example": null
-          },
-          "message": {
-            "type": "string",
-            "example": "<success-message>"
-          },
-          "env": {
-            "type": "string",
-            "example": "production"
-          },
-          "log": {
-            "type": "object",
-            "example": null
-          }
-        }
-      },
-      "subscription_trial_response": {
-        "type": "object",
-        "properties": {
-          "status": {
-            "type": "integer",
-            "example": 200
-          },
-          "data": {
-            "type": "object",
-            "required": [
-              "invoice"
-            ],
-            "properties": {
-              "subscription_id": {
-                "type": "string",
-                "description": "Subscription ID."
-              }
-            },
-            "example": {
-              "subscription_id": "rec_sample-4caac117ca-abeb80"
-            }
-          },
-          "error": {
-            "type": "string",
-            "example": null
-          },
-          "message": {
-            "type": "string",
-            "example": "<success-message>"
-          },
-          "env": {
-            "type": "string",
-            "example": "production"
-          },
-          "log": {
-            "type": "object",
-            "example": null
-          }
-        }
-      },
-      "subscription_invoice_response": {
-        "type": "object",
-        "properties": {
-          "status": {
-            "type": "integer",
-            "example": 200
-          },
-          "data": {
-            "type": "object",
-            "required": [
-              "url",
-              "uniqid"
-            ],
-            "properties": {
-              "url": {
-                "type": "string",
-                "description": "Sellix hosted payment page."
-              },
-              "uniqid": {
-                "type": "string",
-                "format": "uuid",
-                "description": "Unique ID of the invoice created for the subscription."
-              }
-            },
-            "example": {
-              "url": "https://sellix.io/payment/sample-4caac117ca-abeb80",
-              "uniqid": "sample-4caac117ca-abeb80"
-            }
-          },
-          "error": {
-            "type": "string",
-            "example": null
-          },
-          "message": {
-            "type": "string",
-            "example": "<success-message>"
-          },
-          "env": {
-            "type": "string",
-            "example": "production"
-          },
-          "log": {
-            "type": "object",
-            "example": null
-          }
-        }
-      },
-      "gateways": {
-        "type": "array",
-        "items": {
-          "type": "string",
-          "enum": [
-            "PAYPAL",
-            "STRIPE",
-            "SKRILL",
-            "PERFECT_MONEY",
-            "CASH_APP",
-            "BINANCE",
-            "BITCOIN",
-            "LITECOIN",
-            "ETHEREUM",
-            "BITCOIN_CASH",
-            "NANO",
-            "MONERO",
-            "SOLANA",
-            "RIPPLE",
-            "BINANCE_COIN",
-            "USDC:ERC20",
-            "USDC:BEP20",
-            "USDC:MATIC",
-            "USDC:SOL",
-            "USDT:ERC20",
-            "USDT:BEP20",
-            "USDT:MATIC",
-            "USDT:SOL",
-            "USDT:TRC20",
-            "TRON",
-            "BITCOIN_LN",
-            "CONCORDIUM",
-            "POLYGON",
-            "PEPE:ERC20",
-            "DAI:ERC20",
-            "DAI:BEP20",
-            "DAI:MATIC",
-            "WETH:BEP20",
-            "WETH:MATIC",
-            "APE:ERC20",
-            "APE:MATIC",
-            "SHIB:ERC20",
-            "SHIB:BEP20",
-            "SHIB:MATIC",
-            "USDC_NATIVE:MATIC",
-            "DOGECOIN",
-            "PYTH:SOL",
-            "BONK:SOL",
-            "JUP:SOL",
-            "JITO:SOL",
-            "WEN:SOL",
-            "RENDER:SOL",
-            "MOBILE:SOL",
-            "HNT:SOL"
-          ]
-        },
-        "example": [
-          "PAYPAL",
-          "STRIPE",
-          "BITCOIN"
-        ]
-      },
-      "currency": {
-        "type": "string",
-        "enum": [
-          "CAD",
-          "HKD",
-          "ISK",
-          "PHP",
-          "DKK",
-          "HUF",
-          "CZK",
-          "GBP",
-          "RON",
-          "SEK",
-          "IDR",
-          "INR",
-          "BRL",
-          "RUB",
-          "HRK",
-          "JPY",
-          "THB",
-          "CHF",
-          "EUR",
-          "MYR",
-          "BGN",
-          "TRY",
-          "CNY",
-          "NOK",
-          "NZD",
-          "ZAR",
-          "USD",
-          "MXN",
-          "SGD",
-          "AUD",
-          "ILS",
-          "KRW",
-          "PLN"
-        ],
-        "example": "EUR",
-        "description": "Available currency."
-      },
-      "blockchain": {
-        "type": "string",
-        "enum": [
-          "ERC20",
-          "BEP20",
-          "TRC20",
-          "MATIC",
-          "SOL"
-        ],
-        "example": null,
-        "description": "The blockchain of the crypto currency."
-      },
-      "paypal_dispute": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "example": "PP-D-sample1379",
-            "description": "Unique ID of the resource, used as reference across the API."
-          },
-          "invoice_id": {
-            "type": "string",
-            "format": "uuid",
-            "example": "sample-bd73112377-6c0064",
-            "description": "Unique ID of the invoice linked to this dispute."
-          },
-          "shop_id": {
-            "type": "integer",
-            "example": 987,
-            "description": "The shop ID to which this paypal dispute belongs."
-          },
-          "reason": {
-            "type": "string",
-            "enum": [
-              "MERCHANDISE_OR_SERVICE_NOT_RECEIVED",
-              "INCORRECT_AMOUNT",
-              "MERCHANDISE_OR_SERVICE_NOT_AS_DESCRIBED",
-              "PAYMENT_BY_OTHER_MEANS",
-              "UNAUTHORISED",
-              "CANCELED_RECURRING_BILLING",
-              "CREDIT_NOT_PROCESSED",
-              "PROBLEM_WITH_REMITTANCE",
-              "DUPLICATE_TRANSACTION",
-              "OTHER"
-            ],
-            "example": "MERCHANDISE_OR_SERVICE_NOT_RECEIVED",
-            "description": "The dispute reason is why the customer has opened a dispute against your order."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "OPEN",
-              "UNDER_REVIEW",
-              "WAITING_FOR_BUYER_RESPONSE",
-              "RESOLVED",
-              "WAITING_FOR_SELLER_RESPONSE",
-              "OTHER"
-            ],
-            "example": "WAITING_FOR_BUYER_RESPONSE",
-            "description": "Each dispute is automatically updated when we receive an update from PayPal, the status indicates how it is going."
-          },
-          "outcome": {
-            "type": "string",
-            "enum": [
-              "RESOLVED_BUYER_FAVOUR",
-              "CANCELED_BY_BUYER",
-              "RESOLVED_SELLER_FAVOUR",
-              "ACCEPTED",
-              "RESOLVED_WITH_PAYOUT",
-              "DENIED",
-              "NONE"
-            ],
-            "example": null,
-            "description": "When a dispute it’s solved, its outcome is updated."
-          },
-          "messages": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/paypal_dispute_message"
-            },
-            "example": [
-              {
-                "posted_by": "SELLER",
-                "content": "Hello your order is completed",
-                "created_at": 1641033844
-              }
-            ]
-          },
-          "life_cycle_stage": {
-            "type": "string",
-            "enum": [
-              "INQUIRY",
-              "ARBITRATION",
-              "CHARGEBACK",
-              "PRE_ARBITRATION"
-            ],
-            "example": "INQUIRY",
-            "description": "The stage in the dispute lifecycle."
-          },
-          "seller_response_due_date": {
-            "type": "integer",
-            "format": "timestamp",
-            "example": 987,
-            "description": "Within which date the seller needs to respond."
-          },
-          "created_at": {
-            "type": "integer",
-            "format": "timestamp",
-            "example": 162857125819,
-            "description": "Timestamp for the creation of the dispute."
-          },
-          "updated_at": {
-            "type": "integer",
-            "format": "timestamp",
-            "example": 162857125819,
-            "description": "When the dispute was updated."
-          }
-        }
-      },
-      "paypal_dispute_message": {
-        "type": "object",
-        "properties": {
-          "posted_by": {
-            "type": "string",
-            "enum": [
-              "BUYER",
-              "ARBITER",
-              "SELLER"
-            ],
-            "example": "SELLER",
-            "description": "Indicates whether the customer, merchant, or dispute arbiter posted the message."
-          },
-          "content": {
-            "type": "string",
-            "example": "Hello your order is completed",
-            "description": "The content of the dispute message."
-          },
-          "created_at": {
-            "type": "integer",
-            "format": "timestamp",
-            "example": 162857125819,
-            "description": "Timestamp for when the message was sent"
-          }
-        }
-      },
-      "license": {
+      "whitelist": {
         "type": "object",
         "properties": {
           "id": {
@@ -9999,670 +10616,53 @@
           "uniqid": {
             "type": "string",
             "format": "uuid",
-            "example": "546f3ede4f1ad",
+            "example": "sample29a0e39d",
             "description": "Unique ID of the resource, used as reference across the API."
           },
           "shop_id": {
             "type": "integer",
             "example": 987,
-            "description": "The shop ID to which this license belongs."
-          },
-          "product_id": {
-            "type": "string",
-            "example": "sample29a0e39d",
-            "description": "The product ID to which this license belongs."
-          },
-          "invoice_id": {
-            "type": "string",
-            "format": "uuid",
-            "example": "sample-3ddfc9dc3d-ab2e3",
-            "description": "Unique ID of the invoice this license is linked to."
-          },
-          "license_key": {
-            "type": "string",
-            "example": "LICENSE-SAMPLE-00",
-            "description": "License key."
-          },
-          "hardware_id": {
-            "type": "string",
-            "example": "098H52ST479QE053V2",
-            "description": "Hardware ID."
-          },
-          "uses": {
-            "type": "integer",
-            "example": 987,
-            "description": "Number of uses for this license, this value is increased at every license check."
-          },
-          "expires_at": {
-            "type": "string",
-            "format": "date-time",
-            "example": "1970-01-01 00:00:00",
-            "description": "Expiration date of the license."
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "example": "1975-02-28 00:00:00",
-            "description": "Creation date of the license."
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time",
-            "example": "1970-01-01 00:00:00",
-            "description": "Date, available if the license has been updated."
-          }
-        }
-      },
-      "product_variant": {
-        "type": "object",
-        "properties": {
-          "price": { 
-            "type": "number",
-            "example": 60,
-            "description": "The price of the product variant."
-          },
-          "title": { 
-            "type": "string",
-            "example": "exampleTitle",
-            "description": "The title of the product variant."
-          },
-          "description": { 
-            "type": "string",
-            "example": "exampleDescription",
-            "description": "The description of the product variant."
-          },
-          "price_conversions": {
-            "type": "object", 
-            "properties": {
-              "AUD": {
-                "type": "number",
-                "example": 92.08,
-                "description": "The price of the product variant in AUD."
-              },
-              "BGN": {
-                "type": "number",
-                "example": 108.62,
-                "description": "The price of the product variant in BGN."
-              },
-              "BRL": {
-                "type": "number",
-                "example": 300.17,
-                "description": "The price of the product variant in BRL."
-              },
-              "ZAR": {
-                "type": "number",
-                "example": 1143.49,
-                "description": "The price of the product variant in ZAR."
-              },
-              "crypto": {
-                "type": "object",
-                "properties": {
-                  "APE": {
-                    "type": "string",
-                    "example": "31.0607029506",
-                    "description": "The price of the product variant in APE."
-                  },
-                  "BCH": {
-                    "type": "string",
-                    "example": "0.1271212408",
-                    "description": "The price of the product variant in BCH."
-                  },
-                  "BNB": {
-                    "type": "string",
-                    "example": "0.1067436987",
-                    "description": "The price of the product variant in BNB."
-                  },
-                  "USDC_NATIVE": {
-                    "type": "string",
-                    "example": "60.0000000000",
-                    "description": "The price of the product variant in USDC_NATIVE."
-                  }
-                },
-                "description": "A list of the price of the product variant in various cryptocurrencies."
-              }
-            }
-          }
-        },
-        "description": "Product variant object."
-      },
-      "product_addons": {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "id": {
-              "type": "integer",
-              "example": 987
-            },
-            "uniqid": {
-              "type": "string",
-              "example": "sample29a0e39d"
-            },
-            "shop_id": {
-              "type": "integer",
-              "example": 987,
-              "description": "The shop ID to which this addon belongs."
-            },
-            "product_types": {
-              "type": "array",
-              "example": null
-            },
-            "title": {
-              "type": "string",
-              "example": "Sellix"
-            },
-            "description": {
-              "type": "string",
-              "example": "A Sellix product description"
-            },
-            "price": {
-              "type": "string",
-              "example": "1.00"
-            },
-            "currency": {
-              "$ref": "#/components/schemas/currency"
-            }
-          }
-        }
-      },
-      "fee_breakdown": {
-        "type": "object",
-        "properties": {
-          "service_fee": {
-            "type": "object",
-            "properties": {
-              "amount": {
-                "type": "number",
-                "example": 0.5,
-                "description": "The amount of the service fee."
-              },
-              "currency": {
-                "$ref": "#/components/schemas/currency"
-              },
-              "breakdown": {
-                "type": "object",
-                "properties": {
-                  "flat": {
-                    "type": "object",
-                    "properties": {
-                      "amount": {
-                        "type": "number",
-                        "example": 0.5,
-                        "description": "The amount of the service fee."
-                      },
-                      "currency": {
-                        "$ref": "#/components/schemas/currency"
-                      }
-                    }
-                  },
-                  "percentage": {
-                    "type": "object",
-                    "properties": {
-                      "plan": {
-                        "type": "string",
-                        "example": "GATEWAY_NO_FEES",
-                        "description": "The plan of the service fee."
-                      },
-                      "value": {
-                        "type": "number",
-                        "example": "0",
-                        "description": "The amount of the service fee."
-                      },
-                      "amount": {
-                        "type": "number",
-                        "example": "0",
-                        "description": "The amount of the service fee."
-                      },
-                      "currency": {
-                        "$ref": "#/components/schemas/currency"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "aml_analysis": {
-            "type": "object",
-            "properties": {
-              "amount": {
-                "type": "number",
-                "example": 1,
-                "description": "The amount of the service fee."
-              },
-              "currency": {
-                "$ref": "#/components/schemas/currency"
-              },
-              "breakdown": {
-                "type": "object",
-                "properties": {
-                  "flat": {
-                    "type": "object",
-                    "properties": {
-                      "amount": {
-                        "type": "number",
-                        "example": "0",
-                        "description": "The amount of the service fee."
-                      },
-                      "currency": {
-                        "$ref": "#/components/schemas/currency"
-                      }
-                    }
-                  },
-                  "percentage": {
-                    "type": "object",
-                    "properties": {
-                      "amount": {
-                        "type": "number",
-                        "example": 50,
-                        "description": "The amount of the service fee."
-                      },
-                      "currency": {
-                        "$ref": "#/components/schemas/currency"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "platform_fee": {
-            "type": "object",
-            "properties": {
-              "amount": {
-                "type": "number",
-                "example": 1,
-                "description": "The amount of the service fee."
-              },
-              "currency": {
-                "$ref": "#/components/schemas/currency"
-              },
-              "breakdown": {
-                "type": "object",
-                "properties": {
-                  "flat": {
-                    "type": "object",
-                    "properties": {
-                      "amount": {
-                        "type": "number",
-                        "example": 1,
-                        "description": "The amount of the service fee."
-                      },
-                      "currency": {
-                        "$ref": "#/components/schemas/currency"
-                      }
-                    }
-                  },
-                  "percentage": {
-                    "type": "object",
-                    "properties": {
-                      "amount": {
-                        "type": "number",
-                        "example": "0",
-                        "description": "The amount of the service fee."
-                      },
-                      "currency": {
-                        "$ref": "#/components/schemas/currency"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "bundle_config": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "example": 1,
-            "description": "ID of the resource."
-          },
-          "uniqid": {
-            "type": "string",
-            "format": "uuid",
-            "example": "sample29a0e39d",
-            "description": "Unique ID of the bundle, used as reference across the API."
-          },
-          "shop_id": {
-            "type": "integer",
-            "example": 1,
-            "description": "The shop ID to which this bundle belongs."
-          },
-          "title": {
-            "type": "string",
-            "example": "sampleTitle",
-            "description": "The title of the bundle."
-          },
-          "products": {
-            "type": "string",
-            "example": "PRODUCT_ID_1,PRODUCT_ID_2,PRODUCT_ID_3",
-            "description": "The product IDs of the products in the bundle."
-          },
-          "discount_type": {
-            "type": "string",
-            "enum": [
-              "PERCENTAGE",
-              "FIXED"
-            ],
-            "example": "PERCENTAGE",
-            "description": "The type of discount applied to the bundle."
-          },
-          "discount_amount": {
-            "type": "number",
-            "example": 25,
-            "description": "The amount of the discount applied to the bundle."
-          },
-          "updated_at": {
-            "type": "number",
-            "example": 162857125819,
-            "description": "Timestamp, available if the bundle has been updated."
-          }
-        }
-      },
-      "approved_address": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "example": 1,
-            "description": "ID of the resource."
-          },
-          "address": {
-            "type": "string",
-            "example": "btcsda312dsad34132dsa",
-            "description": "The crypto address that was approved."
-          },
-          "coin": {
-            "type": "string",
-            "example": "BTC",
-            "description": "The coin of the approved address."
-          },
-          "blockchain": {
-            "$ref": "#/components/schemas/blockchain"
-          },
-          "tx": {
-            "type": "string",
-            "example": "txid",
-            "description": "The transaction ID of the approval."
-          },
-          "recurring_billing_id": {
-            "type": "string",
-            "example": "rec_sample-4caac117ca-abeb80",
-            "description": "The recurring billing ID of the approval."
-          },
-          "allowance": {
-            "type": "number",
-            "example": 0.0001,
-            "description": "The allowance of the approved address."
-          },
-          "updated_at": {
-            "type": "integer",
-            "example": 162857125819,
-            "description": "Timestamp, available if the approved address has been updated."
-          },
-          "created_at": {
-            "type": "integer",
-            "format": "timestamp",
-            "example": 162857125819,
-            "description": "Timestamp, available if the approved address has been created."
-          }
-        }
-      },
-      "product_download": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "example": 1,
-            "description": "ID of the resource."
-          },
-          "invoice_id": {
-            "type": "string",
-            "format": "uuid",
-            "example": "sample-3ddfc9dc3d-ab2e3",
-            "description": "Unique ID of the invoice this download is linked to."
-          },
-          "customer_ip": {
-            "type": "string",
-            "example": "182.219.207.39",
-            "description": "The IP of the customer that downloaded the product."
-          },
-          "customer_isp": {
-            "type": "string",
-            "example": "WINDTRE",
-            "description": "The ISP of the customer that downloaded the product."
-          },
-          "customer_timezone": {
-            "type": "string",
-            "example": "GMT+1",
-            "description": "The timezone of the customer that downloaded the product."
-          },
-          "customer_country": {
-            "type": "string",
-            "example": "IT",
-            "description": "The country of the customer that downloaded the product."
-          },
-          "created_at": {
-            "type": "integer",
-            "format": "timestamp",
-            "example": 162857125819,
-            "description": "Timestamp, available if the download has been created."
-          }
-        }
-      },
-      "gateway_fees": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "example": 1,
-            "description": "ID of the resource."
-          },
-          "shop_id": {
-            "type": "integer",
-            "example": 1,
-            "description": "The shop ID to which this gateway fee belongs."
-          },
-          "gateway": {
-            "type": "string",
-            "enum": [
-              "PAYPAL",
-              "STRIPE",
-              "SKRILL",
-              "PERFECT_MONEY",
-              "CASH_APP",
-              "BINANCE",
-              "BITCOIN",
-              "LITECOIN",
-              "ETHEREUM",
-              "BITCOIN_CASH",
-              "NANO",
-              "MONERO",
-              "SOLANA",
-              "RIPPLE",
-              "BINANCE_COIN",
-              "USDC:ERC20",
-              "USDC:BEP20",
-              "USDC:MATIC",
-              "USDC:SOL",
-              "USDT:ERC20",
-              "USDT:BEP20",
-              "USDT:MATIC",
-              "USDT:SOL",
-              "USDT:TRC20",
-              "TRON",
-              "BITCOIN_LN",
-              "CONCORDIUM",
-              "POLYGON",
-              "PEPE:ERC20",
-              "DAI:ERC20",
-              "DAI:BEP20",
-              "DAI:MATIC",
-              "WETH:BEP20",
-              "WETH:MATIC",
-              "APE:ERC20",
-              "APE:MATIC",
-              "SHIB:ERC20",
-              "SHIB:BEP20",
-              "SHIB:MATIC",
-              "USDC_NATIVE:MATIC",
-              "DOGECOIN",
-              "PYTH:SOL",
-              "BONK:SOL",
-              "JUP:SOL",
-              "JITO:SOL",
-              "WEN:SOL",
-              "RENDER:SOL",
-              "MOBILE:SOL",
-              "HNT:SOL"
-            ],
-            "example": null,
-            "description": "The gateway of the gateway fee."
-          },
-          "percent_amount": {
-            "type": "number",
-            "example": 3,
-            "description": "The percent amount of the gateway fee."
-          },
-          "fixed_amount": {
-            "type": "number",
-            "example": "0",
-            "description": "The fixed amount of the gateway fee."
-          },
-          "fixed_currency": {
-            "$ref": "#/components/schemas/currency"
-          },
-          "active_type": {
-            "type": "string",
-            "enum": [
-              "PERCENT",
-              "FIXED"
-            ],
-            "example": "PERCENT",
-            "description": "The active type of the gateway fee."
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time",
-            "example": "1975-02-28 15:05:25",
-            "description": "DateTime, available if the gateway fee has been updated."
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "example": "1975-02-28 15:05:25",
-            "description": "DateTime, available if the gateway fee has been created."
-          },
-          "conversions": {
-            "type": "object", 
-            "properties": {
-              "AUD": {
-                "type": "number",
-                "example": 12.43,
-                "description": "The price of the product variant in AUD."
-              },
-              "BGN": {
-                "type": "number",
-                "example": 14.66,
-                "description": "The price of the product variant in BGN."
-              },
-              "BRL": {
-                "type": "number",
-                "example": 40.52,
-                "description": "The price of the product variant in BRL."
-              },
-              "ZAR": {
-                "type": "number",
-                "example": 154.37,
-                "description": "The price of the product variant in ZAR."
-              },
-              "crypto": {
-                "type": "object",
-                "properties": {
-                  "APE": {
-                    "type": "string",
-                    "example": "0.00435",
-                    "description": "The price of the product variant in APE."
-                  },
-                  "BCH": {
-                    "type": "string",
-                    "example": "1.062",
-                    "description": "The price of the product variant in BCH."
-                  },
-                  "BNB": {
-                    "type": "string",
-                    "example": "1.265",
-                    "description": "The price of the product variant in BNB."
-                  },
-                  "USDC_NATIVE": {
-                    "type": "string",
-                    "example": "0.00225",
-                    "description": "The price of the product variant in USDC_NATIVE."
-                  }
-                },
-                "description": "A list of the price of the product variant in various cryptocurrencies."
-              }
-            }
-          }
-        }
-      },
-      "image_attachment": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer"
-          },
-          "uniqid": {
-            "type": "string",
-            "example": "sample2b21744421e9645ed2abef4d303fd16a30fd4bb32f580d7a615ef6e0c7"
-          },
-          "cloudflare_image_id": {
-            "$ref": "#/components/schemas/cloudflare_image_id"
-          },
-          "storage": {
-            "type": "string",
-            "enum": ["PRODUCTS"],
-            "example": "PRODUCTS"
+            "description": "The shop ID to which this whitelist belongs."
           },
           "type": {
             "type": "string",
-            "enum": ["IMAGE"],
-            "example": "IMAGE"
+            "enum": [
+              "EMAIL",
+              "IP",
+              "COUNTRY",
+              "ISP",
+              "ASN",
+              "HOST"
+            ],
+            "example": "EMAIL",
+            "description": "The type of data of this whitelist."
           },
-          "name": {
+          "data": {
             "type": "string",
-            "example": "sample.png"
+            "example": "example@gmail.com",
+            "description": "The value of the whitelist."
           },
-          "original_name": {
+          "note": {
             "type": "string",
-            "example": "file.png"
-          },
-          "extension": {
-            "type": "string",
-            "enum": ["png", "webp", "jpg", "jpeg", "avif", "gif"],
-            "example": "png"
-          },
-          "shop_id": {
-            "type": "integer",
-            "example": 987,
-            "description": "The shop ID to which this resource belongs."
-          },
-          "product_id": {
-            "type": "string",
-            "example": "sample29a0e39d"
-          },
-          "size": {
-            "type": "integer",
-            "example": 987
+            "example": "Admitting known email.",
+            "description": "Additional note provided on whitelist creation."
           },
           "created_at": {
             "type": "integer",
             "format": "timestamp",
             "example": 162857125819,
-            "description": "Timestamp for the creation of the image."
+            "description": "Timestamp for the creation of the whitelist."
+          },
+          "updated_at": {
+            "type": "integer",
+            "format": "timestamp",
+            "example": 162857125819,
+            "description": "Date, available if the whitelist has been edited."
+          },
+          "updated_by": {
+            "type": "integer",
+            "example": 987,
+            "description": "User ID, available if the whitelist has been edited."
           }
         }
       }

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -2164,7 +2164,7 @@
         }
       }
     },
-    "/customers/{uniqid}": {
+    "/customers/{id}": {
       "get": {
         "tags": [
           "Customers"
@@ -2406,7 +2406,7 @@
         }
       }
     },
-    "/subscriptions/{uniqid}": {
+    "/subscriptions/{id}": {
       "get": {
         "tags": [
           "Subscriptions"

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -77,6 +77,9 @@
         "description": "List all the blacklists created on the current shop.",
         "parameters": [
           {
+            "$ref": "#/components/parameters/merchant"
+          },
+          {
             "$ref": "#/components/parameters/page"
           }
         ],
@@ -95,6 +98,11 @@
         ],
         "operationId": "createBlacklist",
         "description": "Create a blacklist",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          }
+        ],
         "requestBody": {
           "description": "blacklist JSON to be created",
           "required": true,
@@ -154,6 +162,9 @@
         "description": "Get a specific blacklist.",
         "parameters": [
           {
+            "$ref": "#/components/parameters/merchant"
+          },
+          {
             "$ref": "#/components/parameters/uniqid"
           }
         ],
@@ -177,6 +188,9 @@
         "description": "Delete a blacklist.",
         "parameters": [
           {
+            "$ref": "#/components/parameters/merchant"
+          },
+          {
             "$ref": "#/components/parameters/uniqid"
           }
         ],
@@ -196,6 +210,9 @@
         "operationId": "updateBlacklist",
         "description": "Update a blacklist",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          },
           {
             "$ref": "#/components/parameters/uniqid"
           }
@@ -255,6 +272,9 @@
         "description": "List all the whitelists created on the current shop.",
         "parameters": [
           {
+            "$ref": "#/components/parameters/merchant"
+          },
+          {
             "$ref": "#/components/parameters/page"
           }
         ],
@@ -273,6 +293,11 @@
         ],
         "operationId": "createWhitelist",
         "description": "Create a whitelist",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          }
+        ],
         "requestBody": {
           "description": "whitelist JSON to be created",
           "required": true,
@@ -332,6 +357,9 @@
         "description": "Get a specific whitelist.",
         "parameters": [
           {
+            "$ref": "#/components/parameters/merchant"
+          },
+          {
             "$ref": "#/components/parameters/uniqid"
           }
         ],
@@ -355,6 +383,9 @@
         "description": "Delete a whitelist.",
         "parameters": [
           {
+            "$ref": "#/components/parameters/merchant"
+          },
+          {
             "$ref": "#/components/parameters/uniqid"
           }
         ],
@@ -374,6 +405,9 @@
         "operationId": "updateWhitelist",
         "description": "Update a whitelist",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          },
           {
             "$ref": "#/components/parameters/uniqid"
           }
@@ -433,6 +467,9 @@
         "description": "List all the categories created on the current shop.",
         "parameters": [
           {
+            "$ref": "#/components/parameters/merchant"
+          },
+          {
             "$ref": "#/components/parameters/page"
           }
         ],
@@ -451,6 +488,11 @@
         ],
         "operationId": "createCategory",
         "description": "Create a category",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          }
+        ],
         "requestBody": {
           "description": "category JSON to be created",
           "required": true,
@@ -519,6 +561,9 @@
         "description": "Get a specific category.",
         "parameters": [
           {
+            "$ref": "#/components/parameters/merchant"
+          },
+          {
             "$ref": "#/components/parameters/uniqid"
           }
         ],
@@ -542,6 +587,9 @@
         "description": "Delete a category.",
         "parameters": [
           {
+            "$ref": "#/components/parameters/merchant"
+          },
+          {
             "$ref": "#/components/parameters/uniqid"
           }
         ],
@@ -561,6 +609,9 @@
         "operationId": "updateCategory",
         "description": "Update a category",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          },
           {
             "$ref": "#/components/parameters/uniqid"
           }
@@ -633,6 +684,9 @@
         "description": "List all the coupons created on the current shop.",
         "parameters": [
           {
+            "$ref": "#/components/parameters/merchant"
+          },
+          {
             "$ref": "#/components/parameters/page"
           }
         ],
@@ -651,6 +705,11 @@
         ],
         "operationId": "createCoupon",
         "description": "Create a coupon",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          }
+        ],
         "requestBody": {
           "description": "coupon JSON to be created",
           "required": true,
@@ -731,6 +790,9 @@
         "description": "Get a specific coupon.",
         "parameters": [
           {
+            "$ref": "#/components/parameters/merchant"
+          },
+          {
             "$ref": "#/components/parameters/uniqid"
           }
         ],
@@ -753,6 +815,9 @@
         "operationId": "deleteCoupon",
         "description": "Delete a coupon.",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          },
           {
             "$ref": "#/components/parameters/uniqid"
           }
@@ -824,6 +889,9 @@
         },
         "parameters": [
           {
+            "$ref": "#/components/parameters/merchant"
+          },
+          {
             "$ref": "#/components/parameters/uniqid"
           }
         ],
@@ -849,6 +917,9 @@
         "description": "List the feedback received on the current shop.",
         "parameters": [
           {
+            "$ref": "#/components/parameters/merchant"
+          },
+          {
             "$ref": "#/components/parameters/page"
           }
         ],
@@ -870,6 +941,9 @@
         "operationId": "getFeedback",
         "description": "Get a specific feedback.",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          },
           {
             "$ref": "#/components/parameters/uniqid"
           }
@@ -916,6 +990,9 @@
         },
         "parameters": [
           {
+            "$ref": "#/components/parameters/merchant"
+          },
+          {
             "$ref": "#/components/parameters/uniqid"
           }
         ],
@@ -938,6 +1015,9 @@
         "description": "List all the orders created on the current shop.",
         "parameters": [
           {
+            "$ref": "#/components/parameters/merchant"
+          },
+          {
             "$ref": "#/components/parameters/page"
           }
         ],
@@ -959,6 +1039,9 @@
         "operationId": "getOrder",
         "description": "Get a specific order.",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          },
           {
             "$ref": "#/components/parameters/uniqid"
           }
@@ -985,6 +1068,9 @@
         "description": "Issue a replacement for a specific order.",
         "parameters": [
           {
+            "$ref": "#/components/parameters/merchant"
+          },
+          {
             "$ref": "#/components/parameters/uniqid"
           }
         ],
@@ -1005,11 +1091,6 @@
         ],
         "operationId": "updateOrder",
         "description": "Update information for a specific order.",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/uniqid"
-          }
-        ],
         "requestBody": {
           "description": "order information to be updated in JSON format",
           "required": true,
@@ -1156,7 +1237,15 @@
               }
             }
           }
-        },
+        },        
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          },
+          {
+            "$ref": "#/components/parameters/uniqid"
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/invoiceUpdated"
@@ -1177,14 +1266,6 @@
         ],
         "operationId": "updateOrder",
         "description": "Update custom_field information for a specific order.",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/uniqid"
-          },
-          {
-            "$ref": "#/components/parameters/custom_fields"
-          }
-        ],
         "requestBody": {
           "description": "order information to be updated in JSON format",
           "required": true,
@@ -1331,7 +1412,18 @@
               }
             }
           }
-        },
+        },        
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          },
+          {
+            "$ref": "#/components/parameters/uniqid"
+          },
+          {
+            "$ref": "#/components/parameters/custom_fields"
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/invoiceUpdated"
@@ -1353,6 +1445,9 @@
         "operationId": "getProducts",
         "description": "List all the products created on the current shop.",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          },
           {
             "$ref": "#/components/parameters/page"
           }
@@ -1548,6 +1643,11 @@
             }
           }
         },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/productCreated"
@@ -1569,6 +1669,9 @@
         "operationId": "getProduct",
         "description": "Get a specific product.",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          },
           {
             "$ref": "#/components/parameters/uniqid"
           }
@@ -1593,6 +1696,9 @@
         "description": "Delete a product.",
         "parameters": [
           {
+            "$ref": "#/components/parameters/merchant"
+          },
+          {
             "$ref": "#/components/parameters/uniqid"
           }
         ],
@@ -1612,6 +1718,9 @@
         "operationId": "updateProduct",
         "description": "Update a product",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          },
           {
             "$ref": "#/components/parameters/uniqid"
           }
@@ -1808,6 +1917,9 @@
         "description": "List all the queries created on the current shop.",
         "parameters": [
           {
+            "$ref": "#/components/parameters/merchant"
+          },
+          {
             "$ref": "#/components/parameters/page"
           }
         ],
@@ -1829,6 +1941,9 @@
         "operationId": "getQuery",
         "description": "Get a specific query.",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          },
           {
             "$ref": "#/components/parameters/uniqid"
           }
@@ -1875,6 +1990,9 @@
         },
         "parameters": [
           {
+            "$ref": "#/components/parameters/merchant"
+          },
+          {
             "$ref": "#/components/parameters/uniqid"
           }
         ],
@@ -1900,6 +2018,9 @@
         "description": "Close a query.",
         "parameters": [
           {
+            "$ref": "#/components/parameters/merchant"
+          },
+          {
             "$ref": "#/components/parameters/uniqid"
           }
         ],
@@ -1921,6 +2042,9 @@
         "operationId": "reopenQuery",
         "description": "Reopen a closed query.",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          },
           {
             "$ref": "#/components/parameters/uniqid"
           }
@@ -2199,6 +2323,11 @@
             }
           }
         },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/payment"
@@ -2221,6 +2350,9 @@
         "description": "Void a payment.",
         "parameters": [
           {
+            "$ref": "#/components/parameters/merchant"
+          },
+          {
             "$ref": "#/components/parameters/uniqid"
           }
         ],
@@ -2240,6 +2372,9 @@
         "operationId": "completePayment",
         "description": "Flag an invoice as paid and process it, sending the purchased product to the customer.",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          },
           {
             "$ref": "#/components/parameters/uniqid"
           }
@@ -2265,6 +2400,9 @@
         "operationId": "getCustomers",
         "description": "List all the customers created on the current shop.",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          },
           {
             "$ref": "#/components/parameters/page"
           }
@@ -2357,6 +2495,11 @@
             }
           }
         },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/customerCreated"
@@ -2378,6 +2521,9 @@
         "operationId": "getCustomer",
         "description": "Get a specific customer.",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          },
           {
             "$ref": "#/components/parameters/id"
           }
@@ -2401,6 +2547,9 @@
         "operationId": "updateCustomer",
         "description": "Update a customer",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          },
           {
             "$ref": "#/components/parameters/id"
           }
@@ -2494,6 +2643,9 @@
         "operationId": "getSubscriptions",
         "description": "List all the subscriptions created on the current shop.",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          },
           {
             "$ref": "#/components/parameters/page"
           }
@@ -2604,6 +2756,11 @@
             }
           }
         },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/subscriptionInvoiceCreated"
@@ -2625,6 +2782,9 @@
         "operationId": "getSubscription",
         "description": "Get a specific subscription.",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          },
           {
             "$ref": "#/components/parameters/id"
           }
@@ -2648,6 +2808,9 @@
         "operationId": "deleteSubscription",
         "description": "Cancel a subscription",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          },
           {
             "$ref": "#/components/parameters/id"
           }
@@ -2702,6 +2865,11 @@
             }
           }
         },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/license"
@@ -2754,6 +2922,11 @@
             }
           }
         },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/license"
@@ -10524,6 +10697,16 @@
         "required": false,
         "example": 1,
         "description": "If pagination is desired, the page to fetch of the response"
+      },
+      "merchant": {
+        "in": "header",
+        "name": "X-Sellix-Merchant",
+        "schema": {
+          "type": "string"
+        },
+        "required": false,
+        "example": "Sellix",
+        "description": "The name of the store to perform actions on via the API"
       },
       "custom_fields": {
         "in": "query",

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -978,20 +978,181 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/uniqid"
+          }
+        ],
+        "requestBody": {
+          "description": "order information to be updated in JSON format",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "gateway": {
+                    "type": "string",
+                    "enum": [
+                      "PAYPAL",
+                      "STRIPE",
+                      "SKRILL",
+                      "PERFECT_MONEY",
+                      "CASH_APP",
+                      "BINANCE",
+                      "BITCOIN",
+                      "LITECOIN",
+                      "ETHEREUM",
+                      "BITCOIN_CASH",
+                      "NANO",
+                      "MONERO",
+                      "SOLANA",
+                      "RIPPLE",
+                      "BINANCE_COIN",
+                      "USDC:ERC20",
+                      "USDC:BEP20",
+                      "USDC:MATIC",
+                      "USDC:SOL",
+                      "USDT:ERC20",
+                      "USDT:BEP20",
+                      "USDT:MATIC",
+                      "USDT:SOL",
+                      "USDT:TRC20",
+                      "TRON",
+                      "BITCOIN_LN",
+                      "CONCORDIUM",
+                      "POLYGON",
+                      "PEPE:ERC20",
+                      "DAI:ERC20",
+                      "DAI:BEP20",
+                      "DAI:MATIC",
+                      "WETH:BEP20",
+                      "WETH:MATIC",
+                      "APE:ERC20",
+                      "APE:MATIC",
+                      "SHIB:ERC20",
+                      "SHIB:BEP20",
+                      "SHIB:MATIC",
+                      "USDC_NATIVE:MATIC",
+                      "DOGECOIN",
+                      "PYTH:SOL",
+                      "BONK:SOL",
+                      "JUP:SOL",
+                      "JITO:SOL",
+                      "WEN:SOL",
+                      "RENDER:SOL",
+                      "MOBILE:SOL",
+                      "HNT:SOL"
+                    ],
+                    "example": "STRIPE",
+                    "description": "If null, the customer will be asked automatically to choose a gateway on the Sellix hosted /payment page. If product_id is specified, the gateway must be on in the product's gateways array."
+                  },
+                  "paypal_apm": {
+                    "type": "string",
+                    "enum": [
+                      "bancontact",
+                      "eps",
+                      "trustly",
+                      "mercado",
+                      "paylater",
+                      "sepa",
+                      "venmo",
+                      "blik",
+                      "giropay",
+                      "ideal",
+                      "mybank",
+                      "sofort",
+                      "przelewy24",
+                      "credit"
+                    ],
+                    "example": null,
+                    "description": "If gateway is PAYPAL, a paypal_apm (PayPal Alternative Payment Method) can be specified. To retrieve the available PayPal APM for a specific customer session, please refer to the PayPal SDK using window.paypal.FUNDING and fundingSource to filter out available methods. You can also use our documentation on how to process white_label payments."
+                  },
+                  "name": {
+                    "type": "string",
+                    "example": "Sellix",
+                    "description": "The name of the recipient for the order"
+                  },
+                  "surname": {
+                    "type": "string",
+                    "example": "SRL",
+                    "description": "The surname of the recipient for the order"
+                  },
+                  "address_line1": {
+                    "type": "string",
+                    "example": "Via del Monte 1",
+                    "description": "The address line of the the order"
+                  },
+                  "address_city": {
+                    "type": "string",
+                    "example": "Bologna",
+                    "description": "The city the address is located in"
+                  },
+                  "address_country": {
+                    "type": "string",
+                    "example": "IT",
+                    "description": "The ISO country code country the address is located in"
+                  },
+                  "address_postal_code": {
+                    "type": "string",
+                    "example": "40126",
+                    "description": "The zipcode for the address"
+                  },
+                  "address_state": {
+                    "type": "string",
+                    "example": "BO",
+                    "description": "The state the address is located"
+                  },
+                  "stripe_apm": {
+                    "type": "string",
+                    "enum": [
+                      "afterpay_clearpay",
+                      "alipay",
+                      "bancontact",
+                      "au_becs_debit",
+                      "boleto",
+                      "eps",
+                      "fpx",
+                      "giropay",
+                      "grabpay",
+                      "ideal",
+                      "klarna",
+                      "oxxo",
+                      "p24",
+                      "sofort",
+                      "wechat_pay"
+                    ],
+                    "example": null,
+                    "description": "Stripe Alternative Payment Method name, such as iDEAL, used if gateway is STRIPE."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/invoiceUpdated"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          }
+        }
+      }
+    },
+    "/orders/{uniqid}/custom_fields": {
+      "put": {
+        "tags": [
+          "Orders"
+        ],
+        "operationId": "updateOrder",
+        "description": "Update custom_field information for a specific order.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/uniqid"
           },
           {
-            "name": "custom_fields",
-            "in": "query",
-            "required": false,
-            "description": "Any number of query parameters in the form of variable=value. Each query parameter represents a custom_field for the invoice.",
-            "schema": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
-            },
-            "style": "form",
-            "explode": true
+            "$ref": "#/components/parameters/custom_fields"
           }
         ],
         "requestBody": {
@@ -10303,6 +10464,19 @@
         "required": true,
         "example": "sample6978a0e39d",
         "description": "ID of the resource"
+      },
+      "custom_fields": {
+        "in": "query",
+        "name": "custom_field_name",
+        "required": false,
+        "description": "The key of the custom field you want to enter. This is a placeholder. Add any amount of query parameters for custom fields you want to change/add.",
+        "schema": {
+          "type": "string",
+          "example": "custom_field_value",
+          "description": "The value of the custom Field"
+        },
+        "style": "form",
+        "explode": true
       }
     },
     "responses": {

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -10668,46 +10668,6 @@
       }
     },
     "parameters": {
-      "uniqid": {
-        "in": "path",
-        "name": "uniqid",
-        "schema": {
-          "type": "string"
-        },
-        "required": true,
-        "example": "sample29a0e39d",
-        "description": "Uniqid of the resource"
-      },
-      "id": {
-        "in": "path",
-        "name": "id",
-        "schema": {
-          "type": "string"
-        },
-        "required": true,
-        "example": "sample6978a0e39d",
-        "description": "ID of the resource"
-      },
-      "page": {
-        "in": "query",
-        "name": "page",
-        "schema": {
-          "type": "integer"
-        },
-        "required": false,
-        "example": 1,
-        "description": "If pagination is desired, the page to fetch of the response"
-      },
-      "merchant": {
-        "in": "header",
-        "name": "X-Sellix-Merchant",
-        "schema": {
-          "type": "string"
-        },
-        "required": false,
-        "example": "Sellix",
-        "description": "The name of the store to perform actions on via the API"
-      },
       "custom_fields": {
         "in": "query",
         "name": "custom_field_name",
@@ -10720,6 +10680,46 @@
         },
         "style": "form",
         "explode": true
+      },
+      "id": {
+        "in": "path",
+        "name": "id",
+        "schema": {
+          "type": "string"
+        },
+        "required": true,
+        "example": "sample6978a0e39d",
+        "description": "ID of the resource"
+      },
+      "merchant": {
+        "in": "header",
+        "name": "X-Sellix-Merchant",
+        "schema": {
+          "type": "string"
+        },
+        "required": false,
+        "example": "Sellix",
+        "description": "The name of the store to perform actions on via the API"
+      },
+      "page": {
+        "in": "query",
+        "name": "page",
+        "schema": {
+          "type": "integer"
+        },
+        "required": false,
+        "example": 1,
+        "description": "If pagination is desired, the page to fetch of the response"
+      },
+      "uniqid": {
+        "in": "path",
+        "name": "uniqid",
+        "schema": {
+          "type": "string"
+        },
+        "required": true,
+        "example": "sample29a0e39d",
+        "description": "Uniqid of the resource"
       }
     },
     "responses": {

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -774,7 +774,7 @@
         },
         "responses": {
           "200": {
-            "$ref": "#/components/responses/200"
+            "$ref": "#/components/responses/couponCreated"
           },
           "400": {
             "$ref": "#/components/responses/400"
@@ -11785,12 +11785,7 @@
                 },
                 "data": {
                   "type": "object",
-                  "properties": {
-                    "uniqid": {
-                      "type": "string",
-                      "example": "sample29a0e39d"
-                    }
-                  }
+                  "example": null
                 },
                 "error": {
                   "type": "string",
@@ -11798,7 +11793,7 @@
                 },
                 "message": {
                   "type": "string",
-                  "example": "<resource> Created Successfully"
+                  "example": "<success-message>"
                 },
                 "env": {
                   "type": "string",
@@ -12292,6 +12287,43 @@
                 "message": {
                   "type": "string",
                   "example": null
+                },
+                "env": {
+                  "type": "string",
+                  "example": "production"
+                }
+              }
+            }
+          }
+        }
+      },
+      "couponCreated": {
+        "description": "resource retrieved",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "integer",
+                  "example": 200
+                },
+                "data": {
+                  "type": "object",
+                  "properties": {
+                    "uniqid": {
+                      "type": "string",
+                      "example": "sample29a0e39d"
+                    }
+                  }
+                },
+                "error": {
+                  "type": "string",
+                  "example": null
+                },
+                "message": {
+                  "type": "string",
+                  "example": "Coupon Created Successfully."
                 },
                 "env": {
                   "type": "string",

--- a/api-reference/orders/update-custom-fields.mdx
+++ b/api-reference/orders/update-custom-fields.mdx
@@ -1,0 +1,4 @@
+---
+title: "Update Custom Fields"
+openapi: put /orders/{uniqid}/custom_fields
+---

--- a/api-reference/payments.mdx
+++ b/api-reference/payments.mdx
@@ -20,7 +20,7 @@ You can also pass a `product_id` or multiple `product_ids` through a cart object
   </Card>
 </CardGroup>
 <CardGroup cols={2}>
-  <Card title="Get Order" icon="dice-one" href="/api-reference/orders/list-orders">
+  <Card title="Get Order" icon="dice-one" href="/api-reference/orders/get-order">
     Get the details of one of your payments (referenced as `order` in the API)
   </Card>
   <Card title="List Orders" icon="bars-staggered" href="/api-reference/orders/list-orders">

--- a/api-reference/subscriptions/delete-subscriptions.mdx
+++ b/api-reference/subscriptions/delete-subscriptions.mdx
@@ -1,4 +1,4 @@
 ---
 title: "Cancel Subscription"
-openapi: delete /subscriptions/{uniqid}
+openapi: delete /subscriptions/{id}
 ---

--- a/api-reference/subscriptions/get-subscription.mdx
+++ b/api-reference/subscriptions/get-subscription.mdx
@@ -1,4 +1,4 @@
 ---
 title: "Get Subscription"
-openapi: get /subscriptions/{uniqid}
+openapi: get /subscriptions/{id}
 ---

--- a/api-reference/values.mdx
+++ b/api-reference/values.mdx
@@ -11,12 +11,13 @@ Our documentation leverages [OpenAPI](https://swagger.io/) for rendering. OpenAP
 - **Object**: `{}`
 - **Array**: `["<any>"]`
 - **Boolean**: `true`
+- **Any**: `<any>`
 
 ## Handling Deprecated Fields
 In cases where a field is deprecated, our API continues to include the field in all requests as `null`, however, it will be rendered as `"null"`, in a string format, in all of our documentation examples. This approach is maintained for backward compatibility, ensuring that integrations remain functional without disruption. Deprecated fields will also have the `"DEPRECATED"` prefix in their descriptions.
 
 ## Stringified values
-In our documentation, you will find instances where integers, booleans and floats are stringified (wrapped in a string). These values should be interpreted as the type of the value inside the string. The examples below should be the only instances in the whole documentation where stringified values should occur. If you see any other values stringified, the API returns them as such.
+In our documentation, you will find instances where integers, booleans and floats are stringified (wrapped in a string). These values should be interpreted as the type of the value inside the string. The examples below should show the only instances in the whole documentation where stringified values should occur. If you see any other values stringified, the API returns them as such.
 - `"0"` should be interpreted as the **integer** `0`
 - `"false"` should be interpreted as the **boolean** `false`
 

--- a/mint.json
+++ b/mint.json
@@ -93,9 +93,9 @@
       ]
     },
     {
-      "group": "Sellix Pay",
+      "group": "Information",
       "pages": [
-        "api-reference/payments"
+        "api-reference/information/get-self"
       ]
     },
     {

--- a/mint.json
+++ b/mint.json
@@ -106,6 +106,7 @@
         "api-reference/orders/list-orders",
         "api-reference/orders/replace-order",
         "api-reference/orders/update-order",
+        "api-reference/orders/update-custom-fields",
         "api-reference/payments/delete-payments"
       ]
     },

--- a/mint.json
+++ b/mint.json
@@ -86,6 +86,7 @@
         "api-reference/dynamic-products",
         "api-reference/payment-methods",
         "api-reference/prefilled-links",
+        "api-reference/payments",
         "api-reference/subscriptions",
         "api-reference/disputes",
         "api-reference/licenses"
@@ -100,14 +101,19 @@
     {
       "group": "Payments",
       "pages": [
-        "api-reference/orders/get-order",
         "api-reference/payments/post-payments",
         "api-reference/payments/put-payments",
+        "api-reference/payments/delete-payments"
+      ]
+    },
+    {
+      "group": "Orders",
+      "pages": [
+        "api-reference/orders/get-order",
         "api-reference/orders/list-orders",
         "api-reference/orders/replace-order",
         "api-reference/orders/update-order",
-        "api-reference/orders/update-custom-fields",
-        "api-reference/payments/delete-payments"
+        "api-reference/orders/update-custom-fields"
       ]
     },
     {

--- a/mint.json
+++ b/mint.json
@@ -182,6 +182,16 @@
       ]
     },
     {
+      "group": "Groups",
+      "pages": [
+        "api-reference/groups/get-group",
+        "api-reference/groups/post-groups",
+        "api-reference/groups/list-groups",
+        "api-reference/groups/put-groups",
+        "api-reference/groups/delete-groups"
+      ]
+    },
+    {
       "group": "Coupons",
       "pages": [
         "api-reference/coupons/get-coupon",


### PR DESCRIPTION
### Description
Added groups endpoints, refactored some pages, split Orders section into Orders and Payments, and added `/v1/self` endpoint.

### Changes
* Added the groups endpoints to a Groups category on the documentation
* Added parameter for `X-Sellix-Merchant` header to all endpoints
* Added query parameter for pagination to all endpoints that return an array of data.
* Alphabetized schemas 
* Added `/orders/:uniqid/custom_fields` and removed custom_field query param from `/orders/update/:uniqid` route
* Fixed an error with redirection on the payments page
* Moved payments page to the **API Documentation** section, deleted **Sellix Pay** section, and moved `/payments` routes to a new **Payments** section
* Added an **Information** section with the `/v1/self` route to get current shop information
* Updated response for coupon 200 status
* Fixed some issues with customer routes displaying the wrong response.
* Made sure all endpoints had the correct data title.