### PR TITLE
Fix bearer header API playground requests

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -3096,9 +3096,8 @@
   "components": {
     "securitySchemes": {
       "bearerAuth": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "Authorization"
+        "type": "http",
+        "scheme": "bearer"
       }
     },
     "schemas": {


### PR DESCRIPTION
@danieleServadei Currently Sellix docs don't include "Bearer" in the `Authorization` header, so anytime someone tries to enter their API key and use it, it won't work unless they prepend `Bearer ` to their API key.

This pull request fixes that.

![main_large](https://github.com/Sellix/developers/assets/83034852/65a50edc-f8e9-4e39-bd81-6fcdb6d62a01)
![main_large](https://github.com/Sellix/developers/assets/83034852/5892d2e6-7522-4145-8338-de0a13760290)

Also, only @Crspy2 commits are actually changing the docs website. So it seems he either needs to merge the pull requests, or you need to upgrade your plan on Mintlify.

![main_large](https://github.com/Sellix/developers/assets/83034852/a177d363-0082-4646-9d32-00bb9a0a1fef)
![image](https://github.com/Sellix/developers/assets/83034852/7e1f2667-e5f7-44e9-ba55-14765c71492f)
