### PR TITLE
Adjust the customer routes to specify that emails also work in path parameters

### DIFF
--- a/api-reference/customers/get-customer.mdx
+++ b/api-reference/customers/get-customer.mdx
@@ -1,4 +1,4 @@
 ---
 title: "Get Customer"
-openapi: get /customers/{id}
+openapi: get /customers/{id_or_email}
 ---

--- a/api-reference/customers/put-customers.mdx
+++ b/api-reference/customers/put-customers.mdx
@@ -1,4 +1,4 @@
 ---
 title: "Update Customer"
-openapi: put /customers/{id}
+openapi: put /customers/{id_or_email}
 ---

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -2635,7 +2635,7 @@
         }
       }
     },
-    "/customers/{id}": {
+    "/customers/{id_or_email}": {
       "get": {
         "tags": [
           "Customers"
@@ -2647,7 +2647,7 @@
             "$ref": "#/components/parameters/merchant"
           },
           {
-            "$ref": "#/components/parameters/id"
+            "$ref": "#/components/parameters/id_or_email"
           }
         ],
         "responses": {
@@ -2673,7 +2673,7 @@
             "$ref": "#/components/parameters/merchant"
           },
           {
-            "$ref": "#/components/parameters/id"
+            "$ref": "#/components/parameters/id_or_email"
           }
         ],
         "requestBody": {
@@ -3096,9 +3096,8 @@
   "components": {
     "securitySchemes": {
       "bearerAuth": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "Authorization"
+        "type": "http",
+        "scheme": "bearer"
       }
     },
     "schemas": {
@@ -11734,6 +11733,16 @@
         "required": true,
         "example": "sample6978a0e39d",
         "description": "ID of the resource"
+      },
+      "id_or_email": {
+        "in": "path",
+        "name": "id or email",
+        "schema": {
+          "type": "string"
+        },
+        "required": true,
+        "example": "sample6978a0e39d",
+        "description": "ID or email associated with the customer"
       },
       "merchant": {
         "in": "header",


### PR DESCRIPTION
Changed path parameter in `/customers/{path_param}` GET and PUT route to specify email and id are both valid parameter types. 

Also, specified bearer schema for "Authorization" header so it prepends Bearer to the token in docs. This was done by syncing the fork, so it includes the following PR [#13](https://github.com/Sellix/developers/pull/13), which was not added to the production deployment of docs cause Mintlify sucks.