### PR TITLE
Add pages for new sellix offerings

### DIFF
--- a/api-reference/customers/customer-balance.mdx
+++ b/api-reference/customers/customer-balance.mdx
@@ -1,0 +1,4 @@
+---
+title: "Customer Affiliate Balance"
+openapi: post /customers/{id_or_email}/affiliate_balance
+---

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -2203,9 +2203,13 @@
                   },
                   "product_id": {
                     "type": "string",
-                    "format": "uuid",
-                    "example": null,
+                    "example": "sample2bde8a50",
                     "description": "If specified value, currency and custom_fields will be taken from the product details."
+                  },
+                  "product_plans": {
+                    "type": "object",
+                    "example": {"sample2bde8a50": "pp_622886e03cbf6a40d5d1f0"},
+                    "description": "Required for subscriptions V2. Specified which plan to use for the invoice."
                   },
                   "cart": {
                     "type": "object",
@@ -2428,8 +2432,7 @@
                   },
                   "webhook": {
                     "type": "string",
-                    "example": "https://dev.sellix.io/v1/webhook",
-                    "description": "Webhook URL to which updates regarding this payment (invoice) will be sent."
+                    "description": "DEPRECATED: Webhook URL to which updates regarding this payment (invoice) will be sent."
                   },
                   "white_label": {
                     "type": "boolean",
@@ -7781,7 +7784,8 @@
               "SERVICE",
               "DYNAMIC",
               "INFO_CARD",
-              "SUBSCRIPTION"
+              "SUBSCRIPTION",
+              "SUBSCRIPTION_V2"
             ],
             "example": "SUBSCRIPTION",
             "description": "Product type."
@@ -9520,7 +9524,8 @@
               "SERVICE",
               "DYNAMIC",
               "INFO_CARD",
-              "SUBSCRIPTION"
+              "SUBSCRIPTION",
+              "SUBSCRIPTION_V2"
             ],
             "example": "SUBSCRIPTION",
             "description": "Product type."
@@ -10274,7 +10279,180 @@
                 }
               }
             }
-          }
+          },
+          "product_plans": {
+            "type": "array",
+            "description": "Product plan information if the product is a SUBSCRIPTION_V2",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer",
+                  "description": "The ID of the resource.",
+                  "example": 987
+                },
+                "uniqid": {
+                  "type": "string",
+                  "description": "The unique identifier for the payment plan.",
+                  "example": "pp_b7dded91285bb657098ac0"
+                },
+                "shop_id": {
+                  "type": "integer",
+                  "description": "The shop ID to which this resource belongs.",
+                  "example": 987
+                },
+                "product_id": {
+                  "type": "integer",
+                  "description": "ID of the product subscription.",
+                  "example": "samplede6277597"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": ["ACTIVE", "INACTIVE"],
+                  "description": "TODO",
+                  "example": "ACTIVE"
+                },
+                "stock": {
+                  "type": "integer",
+                  "description": "The stock of the subscription plan",
+                  "example": -1
+                },
+                "dynamic_webhook": {
+                  "type": "string",
+                  "description": "DEPRECATED: The webhook to be sent for events related to thsi product.",
+                  "example": ""
+                },
+                "service_text": {
+                  "type": "string",
+                  "description": "The service text to be delievered upon delivery (it product type is SERVICE).",
+                  "example": ""
+                },
+                "title": {
+                  "type": "string",
+                  "description": "The title of the plan.",
+                  "example": "Custom Title"
+                },
+                "price": {
+                  "type": "number",
+                  "format": "float",
+                  "description": "The price of the subscription plan",
+                  "example": 5
+                },
+                "description": {
+                  "type": "string",
+                  "description": "The description for the subscription plan",
+                  "example": "Plan description"
+                },
+                "trial_period": {
+                  "type": "integer",
+                  "description": "Whether a trial period is enabled for the subscription plan",
+                  "example": 0
+                },
+                "recurring_interval": {
+                  "type": "string",
+                  "enum": ["DAY", "WEEK", "MONTH", "YEAR"],
+                  "description": "How often the customer should be invoiced for the subscription.",
+                  "example": "MONTH"
+                },
+                "recurring_interval_count": {
+                  "type": "integer",
+                  "description": "How many times the customer should be invoiced per interval",
+                  "example": 1
+                },
+                "payment_type": {
+                  "type": "string",
+                  "enum": ["ADVANCE", "ARREARS"],
+                  "description": "When the customer will be billed for the subscription.",
+                  "example": "ADVANCE"
+                },
+                "renew_type": {
+                  "type": "string",
+                  "enum": ["CALENDAR", "ANNIVERSARY"],
+                  "description": "How subscription renewals should be handled.",
+                  "example": "CALENDAR"
+                },
+                "billing_type": {
+                  "type": "string",
+                  "enum": ["FULL", "PRORATED"],
+                  "description": "How customers should be billed for the subscription if they purchase through the interval.",
+                  "example": "FULL"
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "When the subscription plan was created",
+                  "example": "2024-09-30 22:38:46"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "When the subscription plan was last updated",
+                  "example": "2024-09-30 22:38:46"
+                },
+                "product_currency": {
+                  "type": "string",
+                  "description": "Default currency for the subscription product",
+                  "example": "USD"
+                },
+                "product_stock": {
+                  "type": "integer",
+                  "description": "The stock of the subscription plan",
+                  "example": -1
+                },
+                "product_type": {
+                  "type": "string",
+                  "description": "The type of the product",
+                  "example": "SUBSCRIPTION_V2"
+                },
+                "product_subtype": {
+                  "type": "string",
+                  "enum": [
+                    "PRODUCT",
+                    "SUBSCRIPTION",
+                    "PUBLIC_REST_API",
+                    "MONTHLY_BILL",
+                    "SHOPPING_CART",
+                    "PRODUCT_SUBSCRIPTION"
+                  ],
+                  "example": null
+                },
+                "real_stock": {
+                  "type": "integer",
+                  "description": "The real stock of the subscription plan",
+                  "example": -1
+                },
+                "price_conversions": {
+                  "type": "object",
+                  "description": "Price conversions for supported currencies",
+                  "properties": {
+                    "USD": {
+                      "type": "number",
+                      "format": "float",
+                      "example": 5
+                    },
+                    "CAD": {
+                      "type": "number",
+                      "format": "float",
+                      "example": 6.82
+                    },
+                    "crypto": {
+                      "type": "object",
+                      "properties": {
+                        "BTC": {
+                          "type": "string",
+                          "example": "0.0000792735"
+                        },
+                        "DOGE": {
+                          "type": "string",
+                          "example": "45.3345736873"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }          
         }
       },
       "product_addons": {

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -1780,6 +1780,218 @@
         }
       }
     },
+    "/products?img=true": {
+      "post": {
+        "tags": [
+          "Products"
+        ],
+        "operationId": "createProduct",
+        "description": "Create a product with an image",
+        "requestBody": {
+          "description": "product JSON to be created",
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": ["image"],
+                "properties": {
+                  "image": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "Image file to upload with the product."
+                  },
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "title",
+                      "price",
+                      "description",
+                      "type"
+                    ],
+                    "properties": {
+                      "title": {
+                        "type": "string",
+                        "example": "Software Activation Keys"
+                      },
+                      "price": {
+                        "type": "number",
+                        "format": "double",
+                        "example": 12.5
+                      },
+                      "description": {
+                        "type": "string",
+                        "example": "Product description example."
+                      },
+                      "currency": {
+                        "$ref": "#/components/schemas/currency"
+                      },
+                      "gateways": {
+                        "$ref": "#/components/schemas/gateways"
+                      },
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "SERIALS",
+                          "FILE",
+                          "SERVICE",
+                          "DYNAMIC",
+                          "INFO_CARD",
+                          "SUBSCRIPTION"
+                        ],
+                        "example": "SERIALS",
+                        "description": "Product type."
+                      },
+                      "serials": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          "activation-key-#1"
+                        ]
+                      },
+                      "serials_remove_duplicates": {
+                        "type": "boolean",
+                        "example": true
+                      },
+                      "service_text": {
+                        "type": "string",
+                        "example": null
+                      },
+                      "stock": {
+                        "type": "integer",
+                        "example": null
+                      },
+                      "dynamic_webhook": {
+                        "type": "string",
+                        "example": null
+                      },
+                      "stock_delimiter": {
+                        "type": "string",
+                        "example": ","
+                      },
+                      "min_quantity": {
+                        "type": "integer",
+                        "example": 1
+                      },
+                      "max_quantity": {
+                        "type": "integer",
+                        "example": 150
+                      },
+                      "delivery_text": {
+                        "type": "string",
+                        "example": "Thank you for the purchase!"
+                      },
+                      "custom_fields": {
+                        "type": "array",
+                        "items": {
+                          "type": "object"
+                        },
+                        "example": null
+                      },
+                      "crypto_confirmations_needed": {
+                        "type": "integer",
+                        "example": 3
+                      },
+                      "max_risk_level": {
+                        "type": "integer",
+                        "example": 85,
+                        "description": "For PAYPAL and STRIPE, maximum risk level to accept payments in order to block fraud attempts."
+                      },
+                      "unlisted": {
+                        "type": "boolean",
+                        "example": false
+                      },
+                      "private": {
+                        "type": "boolean",
+                        "example": false
+                      },
+                      "block_vpn_proxies": {
+                        "type": "boolean",
+                        "example": true,
+                        "description": "Block VPN and Proxy purchases if the gateway is PAYPAL or STRIPE."
+                      },
+                      "sort_priority": {
+                        "type": "integer",
+                        "example": 0
+                      },
+                      "webhooks": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": null
+                      },
+                      "on_hold": {
+                        "type": "boolean",
+                        "example": false
+                      },
+                      "terms_of_service": {
+                        "type": "string",
+                        "example": "ToS to be agreed upon purchase."
+                      },
+                      "warranty": {
+                        "type": "integer",
+                        "example": 86400,
+                        "description": "The length of the warranty in seconds"
+                      },
+                      "warranty_text": {
+                        "type": "string",
+                        "example": "Warranty description."
+                      },
+                      "remove_image": {
+                        "type": "boolean",
+                        "example": false
+                      },
+                      "remove_file": {
+                        "type": "boolean",
+                        "example": false
+                      },
+                      "volume_discounts": {
+                        "type": "array",
+                        "items": {
+                          "type": "object"
+                        },
+                        "example": null
+                      },
+                      "recurring_interval": {
+                        "type": "string",
+                        "example": null
+                      },
+                      "recurring_interval_count": {
+                        "type": "integer",
+                        "example": null
+                      },
+                      "trial_period": {
+                        "type": "integer",
+                        "example": null
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/productCreated"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          }
+        }
+      }
+    },
     "/products/{uniqid}": {
       "get": {
         "tags": [

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -2757,6 +2757,90 @@
         }
       }
     },
+    "/customers/{id_or_email}/affiliate_balance": {
+      "post": {
+        "tags": [
+          "Customers"
+        ],
+        "operationId": "updateCustomer",
+        "description": "Update a customer",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          },
+          {
+            "$ref": "#/components/parameters/id_or_email"
+          }
+        ],
+        "requestBody": {
+          "description": "customer JSON to be updated",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "action": {
+                    "type": "string",
+                    "example": "SET",
+                    "enum": ["SET", "ADD", "SUBTRACT"],
+                    "description": "How the amount should be applied to the customer"
+                  },
+                  "amount": {
+                    "type": "number",
+                    "example": 10,
+                    "description": "The amount the action should apply to the customer"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "resource updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "integer",
+                      "example": 200
+                    },
+                    "data": {
+                      "type": "object",
+                      "example": null
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": null
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Customer affiliate balance updated."
+                    },
+                    "env": {
+                      "type": "string",
+                      "example": "production"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          }
+        }
+      }
+    },
     "/subscriptions": {
       "get": {
         "tags": [

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -6197,6 +6197,11 @@
             "example": "null",
             "description": "DEPRECATED"
           },
+          "secret": {
+            "type": "string",
+            "example": "sample-secret",
+            "description": "An internal Sellix secret used for completing tasks with our internal API"
+          },
           "type": {
             "type": "string",
             "enum": [

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -2239,6 +2239,215 @@
         }
       }
     },
+    "/products/{uniqid}?img=true": {
+      "put": {
+        "tags": [
+          "Products"
+        ],
+        "operationId": "updateProduct",
+        "description": "Update a product",
+        "requestBody": {
+          "description": "product JSON to be created",
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": ["image"],
+                "properties": {
+                  "image": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "Image file to upload with the product."
+                  },
+                  "data": {
+                    "type": "object",
+                    "properties": {
+                      "title": {
+                        "type": "string",
+                        "example": "Software Activation Keys"
+                      },
+                      "price": {
+                        "type": "number",
+                        "format": "double",
+                        "example": 12.5
+                      },
+                      "description": {
+                        "type": "string",
+                        "example": "Product description example."
+                      },
+                      "currency": {
+                        "$ref": "#/components/schemas/currency"
+                      },
+                      "gateways": {
+                        "$ref": "#/components/schemas/gateways"
+                      },
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "SERIALS",
+                          "FILE",
+                          "SERVICE",
+                          "DYNAMIC",
+                          "INFO_CARD",
+                          "SUBSCRIPTION"
+                        ],
+                        "example": "SERIALS",
+                        "description": "Product type."
+                      },
+                      "serials": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": [
+                          "activation-key-#1"
+                        ]
+                      },
+                      "serials_remove_duplicates": {
+                        "type": "boolean",
+                        "example": true
+                      },
+                      "service_text": {
+                        "type": "string",
+                        "example": null
+                      },
+                      "stock": {
+                        "type": "integer",
+                        "example": null
+                      },
+                      "dynamic_webhook": {
+                        "type": "string",
+                        "example": null
+                      },
+                      "stock_delimiter": {
+                        "type": "string",
+                        "example": ","
+                      },
+                      "min_quantity": {
+                        "type": "integer",
+                        "example": 1
+                      },
+                      "max_quantity": {
+                        "type": "integer",
+                        "example": 150
+                      },
+                      "delivery_text": {
+                        "type": "string",
+                        "example": "Thank you for the purchase!"
+                      },
+                      "custom_fields": {
+                        "type": "array",
+                        "items": {
+                          "type": "object"
+                        },
+                        "example": null
+                      },
+                      "crypto_confirmations_needed": {
+                        "type": "integer",
+                        "example": 3
+                      },
+                      "max_risk_level": {
+                        "type": "integer",
+                        "example": 85,
+                        "description": "For PAYPAL and STRIPE, maximum risk level to accept payments in order to block fraud attempts."
+                      },
+                      "unlisted": {
+                        "type": "boolean",
+                        "example": false
+                      },
+                      "private": {
+                        "type": "boolean",
+                        "example": false
+                      },
+                      "block_vpn_proxies": {
+                        "type": "boolean",
+                        "example": true,
+                        "description": "Block VPN and Proxy purchases if the gateway is PAYPAL or STRIPE."
+                      },
+                      "sort_priority": {
+                        "type": "integer",
+                        "example": 0
+                      },
+                      "webhooks": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "example": null
+                      },
+                      "on_hold": {
+                        "type": "boolean",
+                        "example": false
+                      },
+                      "terms_of_service": {
+                        "type": "string",
+                        "example": "ToS to be agreed upon purchase."
+                      },
+                      "warranty": {
+                        "type": "integer",
+                        "example": 86400,
+                        "description": "The length of the warranty in seconds"
+                      },
+                      "warranty_text": {
+                        "type": "string",
+                        "example": "Warranty description."
+                      },
+                      "remove_image": {
+                        "type": "boolean",
+                        "example": false
+                      },
+                      "remove_file": {
+                        "type": "boolean",
+                        "example": false
+                      },
+                      "volume_discounts": {
+                        "type": "array",
+                        "items": {
+                          "type": "object"
+                        },
+                        "example": null
+                      },
+                      "recurring_interval": {
+                        "type": "string",
+                        "example": null
+                      },
+                      "recurring_interval_count": {
+                        "type": "integer",
+                        "example": null
+                      },
+                      "trial_period": {
+                        "type": "integer",
+                        "example": null
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/merchant"
+          },
+          {
+            "$ref": "#/components/parameters/uniqid"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/productUpdated"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          }
+        }
+      }
+    },
     "/queries": {
       "get": {
         "tags": [

--- a/api-reference/products/post-products-image.mdx
+++ b/api-reference/products/post-products-image.mdx
@@ -1,0 +1,4 @@
+---
+title: "Create Product With Image"
+openapi: post /products?img=true
+---

--- a/api-reference/products/put-products-image.mdx
+++ b/api-reference/products/put-products-image.mdx
@@ -1,0 +1,4 @@
+---
+title: "Update Product With Image"
+openapi: put /products/{uniqid}?img=true
+---

--- a/mint.json
+++ b/mint.json
@@ -67,6 +67,7 @@
         "products/pos",
         "products/commerce",
         "products/licenses",
+        "products/rcon-products",
         "products/style-center",
         "products/marketing",
         "products/analytics",

--- a/mint.json
+++ b/mint.json
@@ -172,6 +172,7 @@
         "api-reference/products/post-products-image",
         "api-reference/products/list-products",
         "api-reference/products/put-products",
+        "api-reference/products/put-products-image",
         "api-reference/products/delete-products"
       ]
     },

--- a/mint.json
+++ b/mint.json
@@ -124,7 +124,8 @@
         "api-reference/customers/get-customer",
         "api-reference/customers/post-customers",
         "api-reference/customers/list-customers",
-        "api-reference/customers/put-customers"
+        "api-reference/customers/put-customers",
+        "api-reference/customers/customer-balance"
       ]
     },
     {

--- a/mint.json
+++ b/mint.json
@@ -61,17 +61,18 @@
       "pages": [
         "products/platforms",
         "products/wallet-and-crypto",
-        "products/commerce",
-        "products/communities",
         "products/embed",
-        "products/plugins",
         "products/links",
         "products/subscriptions",
         "products/pos",
+        "products/commerce",
         "products/licenses",
+        "products/style-center",
         "products/marketing",
         "products/analytics",
-        "products/fraud-shield"
+        "products/fraud-shield",
+        "products/communities",
+        "products/plugins"
       ]
     },
     {

--- a/mint.json
+++ b/mint.json
@@ -169,6 +169,7 @@
       "pages": [
         "api-reference/products/get-product",
         "api-reference/products/post-products",
+        "api-reference/products/post-products-image",
         "api-reference/products/list-products",
         "api-reference/products/put-products",
         "api-reference/products/delete-products"

--- a/products/embed.mdx
+++ b/products/embed.mdx
@@ -22,7 +22,7 @@ The embed is the easiest way to integrate payment buttons and products within yo
 </Card>
 
 ## Styling
-If you want to edit or remove the **Sellix branding** at the bottom of an embed, or customize the look/style of your embeds, you can use our [Style Center](https://dashboard.sellix.io/style-center).
+If you want to edit or [remove the **Sellix branding**](https://help.sellix.io/en/articles/9817382-how-to-disable-powered-by-sellix-in-the-new-embed-version) at the bottom of an embed, or customize the look/style of your embeds, you can use our [Style Center](https://dashboard.sellix.io/style-center).
 
 
 ## Live demo

--- a/products/embed.mdx
+++ b/products/embed.mdx
@@ -21,6 +21,10 @@ The embed is the easiest way to integrate payment buttons and products within yo
   See the developer documentation to integrate Embeds within your website.
 </Card>
 
+## Styling
+If you want to edit or remove the **Sellix branding** at the bottom of an embed, or customize the look/style of your embeds, you can use our [Style Center](https://dashboard.sellix.io/style-center).
+
+
 ## Live demo
 
 See below a live demo of our embed, created by simply doing

--- a/products/embed.mdx
+++ b/products/embed.mdx
@@ -22,7 +22,7 @@ The embed is the easiest way to integrate payment buttons and products within yo
 </Card>
 
 ## Styling
-If you want to edit or [remove the **Sellix branding**](https://help.sellix.io/en/articles/9817382-how-to-disable-powered-by-sellix-in-the-new-embed-version) at the bottom of an embed, or customize the look/style of your embeds, you can use our [Style Center](https://dashboard.sellix.io/style-center).
+If you want to edit or [remove the **Sellix branding**](https://help.sellix.io/en/articles/9817382-how-to-disable-powered-by-sellix-in-the-new-embed-version) at the bottom of an embed, or customize the look/style of your embeds, you can use our [Style Center](https://docs.sellix.io/products/style-center).
 
 
 ## Live demo

--- a/products/pos.mdx
+++ b/products/pos.mdx
@@ -13,7 +13,7 @@ The Sellix PoS can be used to accept payments directly through your mobile devic
 <Card
   title="PoS Dashboard"
   icon="cash-register"
-  href="https://dashboard.sellix.io/links"
+  href="https://dashboard.sellix.io/pos"
 >
   Access your PoS dashboard to learn more about our system and see recently created invoices.
 </Card>

--- a/products/rcon-products.mdx
+++ b/products/rcon-products.mdx
@@ -13,7 +13,7 @@ If you have a large gaming community and need custom specifications, features, a
 
 <img
   className="block"
-  src="https://ci3.googleusercontent.com/meips/ADKq_NZvufPBiPgy0O6ca7wnkPDLaH0i9gt7N7c3k1AwXGgsW3OrGemWO0f-FiOpAvSLFtt5drqV7DpsSd9k9JdVOybRfpolvDVEMTqww0HuavKtz3osJR4kMnToQyZbnLVLV6Pb54jFExZyS2dsP0F_Os4HezWerzaDbUs=s0-d-e1-ft#https://mcusercontent.com/33d964e60df5e473fe19aab4f/images/f90f6549-06fe-9010-ea41-6b11579d4236.png"
+  src="https://cdn-theme.mysellix.io/docs/rcon.png"
   alt="RCON servers"
 />
 

--- a/products/rcon-products.mdx
+++ b/products/rcon-products.mdx
@@ -1,0 +1,27 @@
+---
+title: 'RCON Products'
+description: 'Automatically reward customers with perks on your server after they purchase a product'
+icon: 'gamepad'
+---
+
+## Sell content directly to your server users
+We're excited to announce one of the biggest updates we're releasing this month: support for RCON gaming and server connections.
+
+Merchants can now directly sell content for their gaming communities (**Ark, GTA V, Minecraft and more**) through Sellix by connecting their servers and configuring products to deliver any asset to any player.
+
+If you have a large gaming community and need custom specifications, features, and/or updates, email sales@sellix.io, and we'll get to it ASAP.
+
+<img
+  className="block"
+  src="https://ci3.googleusercontent.com/meips/ADKq_NZvufPBiPgy0O6ca7wnkPDLaH0i9gt7N7c3k1AwXGgsW3OrGemWO0f-FiOpAvSLFtt5drqV7DpsSd9k9JdVOybRfpolvDVEMTqww0HuavKtz3osJR4kMnToQyZbnLVLV6Pb54jFExZyS2dsP0F_Os4HezWerzaDbUs=s0-d-e1-ft#https://mcusercontent.com/33d964e60df5e473fe19aab4f/images/f90f6549-06fe-9010-ea41-6b11579d4236.png"
+  alt="RCON servers"
+/>
+
+
+<Card
+  title="RCON Servers"
+  icon="gamepad"
+  href="https://dashboard.sellix.io/rcon-servers"
+>
+  Manage your RCON server integrations.
+</Card>

--- a/products/style-center.mdx
+++ b/products/style-center.mdx
@@ -11,8 +11,8 @@ You can now fully customize every single detail and appearance related to your w
 
 <img
   className="block"
-  src="https://ci3.googleusercontent.com/meips/ADKq_NbGvEjSi7e-E6gsBz8CjLo_u36_yM62H1OfnhY4nlqwodXGjIGNRKOFMRG574TJFJI1Y97YUjysCuJLfQ9DUesh16uKUoDKPpfIA__JrpoRPZdvGwO66HhcOoF52cixFt-cXx_vFRQMIaqLmbcsv6txtXmzDm6F0fw=s0-d-e1-ft#https://mcusercontent.com/33d964e60df5e473fe19aab4f/images/a9a1a90d-1829-9931-70b6-a99c04466f0c.png"
-  alt="Fraud shield dashboard"
+  src="https://cdn-theme.mysellix.io/docs/style-center.png"
+  alt="Style Center"
 />
 
 <Card

--- a/products/style-center.mdx
+++ b/products/style-center.mdx
@@ -1,20 +1,8 @@
 ---
 title: 'Style Center'
-description: 'Add custom colors and styles to your Sellix embeds, checkouts, and more...'
+description: 'Apply custom styles and designs to your Sellix storefront and see your dreams become reality.'
 icon: 'image'
 ---
-
-## The Style Center
-
-Apply custom styles and designs to your Sellix storefront and see your dreams become reality.
-
-<Card
-  title="Style Center"
-  icon="image"
-  href="https://dashboard.sellix.io/style-center"
->
-  Access your shop's style center and start customizing now!
-</Card>
 
 ## The Customer Portal is now customizable
 When editing/creating a **custom theme through the Style Center for Embed/Checkout/Link**, that theme will also be applied to your customer portal, accessible at [yourStoreName.mysellix.io/customer/dashboard](https://yourstorename.mysellix.io/customer/dashboard)
@@ -26,3 +14,11 @@ You can now fully customize every single detail and appearance related to your w
   src="https://ci3.googleusercontent.com/meips/ADKq_NbGvEjSi7e-E6gsBz8CjLo_u36_yM62H1OfnhY4nlqwodXGjIGNRKOFMRG574TJFJI1Y97YUjysCuJLfQ9DUesh16uKUoDKPpfIA__JrpoRPZdvGwO66HhcOoF52cixFt-cXx_vFRQMIaqLmbcsv6txtXmzDm6F0fw=s0-d-e1-ft#https://mcusercontent.com/33d964e60df5e473fe19aab4f/images/a9a1a90d-1829-9931-70b6-a99c04466f0c.png"
   alt="Fraud shield dashboard"
 />
+
+<Card
+  title="Style Center"
+  icon="image"
+  href="https://dashboard.sellix.io/style-center"
+>
+  Access your shop's style center and start customizing now!
+</Card>

--- a/products/style-center.mdx
+++ b/products/style-center.mdx
@@ -1,0 +1,28 @@
+---
+title: 'Style Center'
+description: 'Add custom colors and styles to your Sellix embeds, checkouts, and more...'
+icon: 'image'
+---
+
+## The Style Center
+
+Apply custom styles and designs to your Sellix storefront and see your dreams become reality.
+
+<Card
+  title="Style Center"
+  icon="image"
+  href="https://dashboard.sellix.io/style-center"
+>
+  Access your shop's style center and start customizing now!
+</Card>
+
+## The Customer Portal is now customizable
+When editing/creating a **custom theme through the Style Center for Embed/Checkout/Link**, that theme will also be applied to your customer portal, accessible at [yourStoreName.mysellix.io/customer/dashboard](https://yourstorename.mysellix.io/customer/dashboard)
+
+You can now fully customize every single detail and appearance related to your website.
+
+<img
+  className="block"
+  src="https://ci3.googleusercontent.com/meips/ADKq_NbGvEjSi7e-E6gsBz8CjLo_u36_yM62H1OfnhY4nlqwodXGjIGNRKOFMRG574TJFJI1Y97YUjysCuJLfQ9DUesh16uKUoDKPpfIA__JrpoRPZdvGwO66HhcOoF52cixFt-cXx_vFRQMIaqLmbcsv6txtXmzDm6F0fw=s0-d-e1-ft#https://mcusercontent.com/33d964e60df5e473fe19aab4f/images/a9a1a90d-1829-9931-70b6-a99c04466f0c.png"
+  alt="Fraud shield dashboard"
+/>


### PR DESCRIPTION
Adds two pages for Style Center / RCON products and adds style center instructions to embed page.

- [x] `/products/style-center` page
- [x] `/products/rcon-products` page
- [x] edited `/products/embed` page to have instructions to remove Sellix watermark from embeds
- [x] added `POST /customers/{id_or_email}/affiliate_balance` route 
- [x] added "secret" field to data of response body for `GET /orders/{uniqid}` route 